### PR TITLE
retro_dirent and retro_stat tidy and bugfixes

### DIFF
--- a/include/retro_dirent.h
+++ b/include/retro_dirent.h
@@ -43,14 +43,13 @@ const char *retro_dirent_get_name(struct RDIR *rdir);
  *
  * retro_dirent_is_dir:
  * @rdir         : pointer to the directory entry.
- * @path         : path to the directory entry.
  *
  * Is the directory listing entry a directory?
  *
  * Returns: true if directory listing entry is
  * a directory, false if not.
  */
-bool retro_dirent_is_dir(struct RDIR *rdir, const char *path);
+bool retro_dirent_is_dir(struct RDIR *rdir);
 
 void retro_closedir(struct RDIR *rdir);
 

--- a/include/retro_stat.h
+++ b/include/retro_stat.h
@@ -28,6 +28,10 @@
 
 #include <boolean.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * path_is_directory:
  * @path               : path
@@ -53,5 +57,9 @@ int32_t path_get_size(const char *path);
  * Returns: true (1) if directory could be created, otherwise false (0).
  **/
 bool mkdir_norecurse(const char *dir);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lists/dir_list.c
+++ b/lists/dir_list.c
@@ -188,7 +188,7 @@ struct string_list *dir_list_new(const char *dir,
       const char *file_ext            = path_get_extension(name);
 
       fill_pathname_join(file_path, dir, name, sizeof(file_path));
-      is_dir = retro_dirent_is_dir(entry, file_path);
+      is_dir = retro_dirent_is_dir(entry);
 
       ret    = parse_dir_entry(name, file_path, is_dir,
             include_dirs, include_compressed, list, ext_list, file_ext);


### PR DESCRIPTION
retro_dirent and retro_stat tidy and bugfixes: windows retro_dir would have missed the first entry; retro_stat wasn't extern "C"'d; retro_dirent_is_dir didn't need a path argument (path can always be gotten from RDIR in a trivial operation)