### PR TITLE
(stdstring.c) Added string_ucwords to capitalize first letter of each word

### DIFF
--- a/include/string/stdstring.h
+++ b/include/string/stdstring.h
@@ -42,6 +42,8 @@ char *string_to_upper(char *s);
 
 char *string_to_lower(char *s);
 
+char *string_ucwords(char* s);
+
 char *string_replace_substring(const char *in, const char *pattern,
       const char *by);
 

--- a/string/stdstring.c
+++ b/string/stdstring.c
@@ -59,6 +59,21 @@ char *string_to_lower(char *s)
    return s;
 }
 
+char *string_ucwords(char *s)
+{
+  char *cs = (char *)s;
+  for ( ; *cs != '\0'; cs++)
+  {
+    if (*cs == ' ')
+    {
+      *(cs+1) = toupper(*(cs+1));
+    }
+  }
+
+  s[0] = toupper(s[0]);
+  return s;
+}
+
 char *string_replace_substring(const char *in,
       const char *pattern, const char *replacement)
 {


### PR DESCRIPTION
It just iterates over the string and capitalizes each character following a space, then capitalizes the very first character of the string.

I don't know how changes made to this repo are merged with RetroArch's `libretro-common` folder as it doesn't seem to be a submodule.