### PR TITLE
libco/armeabi.c: Remove unused function

### DIFF
--- a/libco/armeabi.c
+++ b/libco/armeabi.c
@@ -53,12 +53,6 @@ asm (
 /* ASM */
 void co_switch_arm(cothread_t handle, cothread_t current);
 
-static void crash(void)
-{
-   /* Called only if cothread_t entrypoint returns. */
-   assert(0);
-}
-
 cothread_t co_create(unsigned int size, void (*entrypoint)(void))
 {
    size = (size + 1023) & ~1023;


### PR DESCRIPTION
The function "crash" was defined in this file, but never used. I removed the function to prevent warnings when using this file.