### PR TITLE
Add missing guards to headers.

### DIFF
--- a/include/encodings/crc32.h
+++ b/include/encodings/crc32.h
@@ -26,6 +26,13 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include <retro_common_api.h>
+
+RETRO_BEGIN_DECLS
+
+
 uint32_t encoding_crc32(uint32_t crc, const uint8_t *buf, size_t len);
+
+RETRO_END_DECLS
 
 #endif

--- a/include/encodings/utf.h
+++ b/include/encodings/utf.h
@@ -28,6 +28,10 @@
 
 #include <boolean.h>
 
+#include <retro_common_api.h>
+
+RETRO_BEGIN_DECLS
+
 size_t utf8_conv_utf32(uint32_t *out, size_t out_chars,
       const char *in, size_t in_size);
 
@@ -43,5 +47,7 @@ const char *utf8skip(const char *str, size_t chars);
 uint32_t utf8_walk(const char **string);
 
 bool utf16_to_char_string(const uint16_t *in, char *s, size_t len);
+
+RETRO_END_DECLS
 
 #endif

--- a/include/file/archive_file.h
+++ b/include/file/archive_file.h
@@ -35,6 +35,10 @@
 
 #include <retro_miscellaneous.h>
 
+#include <retro_common_api.h>
+
+RETRO_BEGIN_DECLS
+
 enum file_archive_transfer_type
 {
    ARCHIVE_TRANSFER_NONE = 0,
@@ -202,6 +206,8 @@ uint32_t file_archive_get_file_crc32(const char *path);
 
 extern const struct file_archive_file_backend zlib_backend;
 extern const struct file_archive_file_backend sevenzip_backend;
+
+RETRO_END_DECLS
 
 #endif
 

--- a/include/file/config_file_userdata.h
+++ b/include/file/config_file_userdata.h
@@ -27,6 +27,10 @@
 
 #include <file/config_file.h>
 
+#include <retro_common_api.h>
+
+RETRO_BEGIN_DECLS
+
 struct config_file_userdata
 {
    config_file_t *conf;
@@ -51,5 +55,7 @@ int config_userdata_get_string(void *userdata, const char *key_str,
       char **output, const char *default_output);
 
 void config_userdata_free(void *ptr);
+
+RETRO_END_DECLS
 
 #endif

--- a/include/file/nbio.h
+++ b/include/file/nbio.h
@@ -26,6 +26,10 @@
 #include <stddef.h>
 #include <boolean.h>
 
+#include <retro_common_api.h>
+
+RETRO_BEGIN_DECLS
+
 #ifndef NBIO_READ
 #define NBIO_READ   0
 #endif
@@ -92,5 +96,7 @@ void nbio_cancel(struct nbio_t* handle);
  * Deletes the nbio structure and its associated pointer.
  */
 void nbio_free(struct nbio_t* handle);
+
+RETRO_END_DECLS
 
 #endif

--- a/include/formats/jsonsax.h
+++ b/include/formats/jsonsax.h
@@ -25,6 +25,11 @@
 
 #include <stddef.h>
 
+#include <retro_common_api.h>
+
+RETRO_BEGIN_DECLS
+
+
 enum
 {
   JSONSAX_OK = 0,
@@ -60,5 +65,7 @@ typedef struct
 jsonsax_handlers_t;
 
 int jsonsax_parse( const char* json, const jsonsax_handlers_t* handlers, void* userdata );
+
+RETRO_END_DECLS
 
 #endif /* __LIBRETRO_SDK_FORMAT_JSONSAX_H__ */

--- a/include/gfx/gl_capabilities.h
+++ b/include/gfx/gl_capabilities.h
@@ -26,6 +26,8 @@
 #include <boolean.h>
 #include <retro_common_api.h>
 
+RETRO_BEGIN_DECLS
+
 enum gl_capability_enum
 {
    GL_CAPS_NONE = 0,
@@ -60,5 +62,7 @@ void gl_query_core_context_unset(void);
 bool gl_check_capability(enum gl_capability_enum enum_idx);
 
 bool gl_query_extension(const char *ext);
+
+RETRO_END_DECLS
 
 #endif

--- a/include/gfx/math/matrix_3x3.h
+++ b/include/gfx/math/matrix_3x3.h
@@ -25,6 +25,10 @@
 
 #include <boolean.h>
 
+#include <retro_common_api.h>
+
+RETRO_BEGIN_DECLS
+
 typedef struct math_matrix_3x3
 {
    float data[9];
@@ -63,5 +67,7 @@ bool matrix_3x3_quad_to_quad(const float dx0, const float dy0,
                              const float sx2, const float sy2,
                              const float sx3, const float sy3,
                              math_matrix_3x3 *mat);
+
+RETRO_END_DECLS
 
 #endif

--- a/include/gfx/math/vector_2.h
+++ b/include/gfx/math/vector_2.h
@@ -25,6 +25,10 @@
 
 #include <stdint.h>
 
+#include <retro_common_api.h>
+
+RETRO_BEGIN_DECLS
+
 typedef float vec2_t[2];
 
 float vec2_dot(const float *a, const float *b);
@@ -36,6 +40,8 @@ void vec2_add(float *dst, const float *src);
 void vec2_subtract(float *dst, const float *src);
 
 void vec2_copy(float *dst, const float *src);
+
+RETRO_END_DECLS
 
 #endif
 

--- a/include/gfx/math/vector_4.h
+++ b/include/gfx/math/vector_4.h
@@ -25,6 +25,10 @@
 
 #include <stdint.h>
 
+#include <retro_common_api.h>
+
+RETRO_BEGIN_DECLS
+
 typedef float vec4_t[4];
 
 void vec4_add(float *dst, const float *src);
@@ -34,6 +38,8 @@ void vec4_subtract(float *dst, const float *src);
 void vec4_scale(float *dst, const float scale);
 
 void vec4_copy(float *dst, const float *src);
+
+RETRO_END_DECLS
 
 #endif
 

--- a/include/gfx/scaler/pixconv.h
+++ b/include/gfx/scaler/pixconv.h
@@ -25,6 +25,11 @@
 
 #include <clamping.h>
 
+#include <retro_common_api.h>
+
+RETRO_BEGIN_DECLS
+
+
 void conv_0rgb1555_argb8888(void *output, const void *input,
       int width, int height,
       int out_stride, int in_stride);
@@ -88,6 +93,8 @@ void conv_yuyv_argb8888(void *output, const void *input,
 void conv_copy(void *output, const void *input,
       int width, int height,
       int out_stride, int in_stride);
+
+RETRO_END_DECLS
 
 #endif
 

--- a/include/gfx/scaler/scaler_int.h
+++ b/include/gfx/scaler/scaler_int.h
@@ -25,6 +25,10 @@
 
 #include <gfx/scaler/scaler.h>
 
+#include <retro_common_api.h>
+
+RETRO_BEGIN_DECLS
+
 void scaler_argb8888_vert(const struct scaler_ctx *ctx,
       void *output, int stride);
 
@@ -36,6 +40,8 @@ void scaler_argb8888_point_special(const struct scaler_ctx *ctx,
       int out_width, int out_height,
       int in_width, int in_height,
       int out_stride, int in_stride);
+
+RETRO_END_DECLS
 
 #endif
 


### PR DESCRIPTION
This is just some work to clean up the libretro-common libraries. Needed for my libretro_loader.exe. 

Still a work in progress.