### PR TITLE
Fix to avoid redefined warnings

### DIFF
--- a/include/streams/file_stream_transforms.h
+++ b/include/streams/file_stream_transforms.h
@@ -32,6 +32,19 @@ typedef struct RFILE RFILE;
 
 #define FILE RFILE
 
+#undef fopen
+#undef fclose
+#undef ftell
+#undef fseek
+#undef fread
+#undef fgets
+#undef fgetc
+#undef fwrite
+#undef fputc
+#undef fprintf
+#undef ferror
+#undef feof
+
 #define fopen rfopen
 #define fclose rfclose
 #define ftell rftell


### PR DESCRIPTION
Those warnings will appear when a define for those functions already exists : VITA, WiiU, Android (32bits), ...