### PR TITLE
win32 - fix bug in sthread_isself

### DIFF
--- a/rthreads/rthreads.c
+++ b/rthreads/rthreads.c
@@ -74,6 +74,7 @@ struct sthread
 {
 #ifdef USE_WIN32_THREADS
    HANDLE thread;
+   DWORD thread_id;
 #else
    pthread_t id;
 #endif
@@ -159,9 +160,6 @@ sthread_t *sthread_create(void (*thread_func)(void*), void *userdata)
    bool thread_created      = false;
    struct thread_data *data = NULL;
    sthread_t *thread        = (sthread_t*)calloc(1, sizeof(*thread));
-#if defined(_WIN32_WINNT) && _WIN32_WINNT <= 0x0410
-   DWORD thread_id          = 0;
-#endif
    if (!thread)
       return NULL;
 
@@ -173,11 +171,7 @@ sthread_t *sthread_create(void (*thread_func)(void*), void *userdata)
    data->userdata = userdata;
 
 #ifdef USE_WIN32_THREADS
-#if defined(_WIN32_WINNT) && _WIN32_WINNT <= 0x0410
-   thread->thread = CreateThread(NULL, 0, thread_wrap, data, 0, &thread_id);
-#else
-   thread->thread = CreateThread(NULL, 0, thread_wrap, data, 0, NULL);
-#endif
+   thread->thread = CreateThread(NULL, 0, thread_wrap, data, 0, &thread->thread_id);
    thread_created = !!thread->thread;
 #else
 #if defined(VITA)
@@ -260,7 +254,7 @@ bool sthread_isself(sthread_t *thread)
   if (!thread) return false;
 
 #ifdef USE_WIN32_THREADS
-   return GetCurrentThread() == thread->thread;
+   return GetCurrentThreadId() == thread->thread_id;
 #else
    return pthread_equal(pthread_self(),thread->id);
 #endif


### PR DESCRIPTION
GetCurrentThread() is useless, it returns a pseudo-handle which is the same value in every thread, or something like that, rendering isself nonfunctional. the thread ID is more useful.