### PR TITLE
Analog buttons

### DIFF
--- a/include/libretro.h
+++ b/include/libretro.h
@@ -131,11 +131,12 @@ extern "C" {
 #define RETRO_DEVICE_LIGHTGUN     4
 
 /* The ANALOG device is an extension to JOYPAD (RetroPad).
- * Similar to DualShock it adds two analog sticks.
- * This is treated as a separate device type as it returns values in the 
- * full analog range of [-0x8000, 0x7fff]. Positive X axis is right.
- * Positive Y axis is down.
- * Only use ANALOG type when polling for analog values of the axes.
+ * Similar to DualShock2 it adds two analog sticks and all buttons can
+ * be analog. This is treated as a separate device type as it returns
+ * axis values in the full analog range of [-0x8000, 0x7fff].
+ * Positive X axis is right. Positive Y axis is down.
+ * Buttons are returned in the range [0, 0x7fff].
+ * Only use ANALOG type when polling for analog values.
  */
 #define RETRO_DEVICE_ANALOG       5
 
@@ -174,7 +175,8 @@ extern "C" {
 /* Buttons for the RetroPad (JOYPAD).
  * The placement of these is equivalent to placements on the 
  * Super Nintendo controller.
- * L2/R2/L3/R3 buttons correspond to the PS1 DualShock. */
+ * L2/R2/L3/R3 buttons correspond to the PS1 DualShock.
+ * Also used as id values for RETRO_DEVICE_INDEX_ANALOG_BUTTON */
 #define RETRO_DEVICE_ID_JOYPAD_B        0
 #define RETRO_DEVICE_ID_JOYPAD_Y        1
 #define RETRO_DEVICE_ID_JOYPAD_SELECT   2
@@ -193,10 +195,11 @@ extern "C" {
 #define RETRO_DEVICE_ID_JOYPAD_R3      15
 
 /* Index / Id values for ANALOG device. */
-#define RETRO_DEVICE_INDEX_ANALOG_LEFT   0
-#define RETRO_DEVICE_INDEX_ANALOG_RIGHT  1
-#define RETRO_DEVICE_ID_ANALOG_X         0
-#define RETRO_DEVICE_ID_ANALOG_Y         1
+#define RETRO_DEVICE_INDEX_ANALOG_LEFT       0
+#define RETRO_DEVICE_INDEX_ANALOG_RIGHT      1
+#define RETRO_DEVICE_INDEX_ANALOG_BUTTON     2
+#define RETRO_DEVICE_ID_ANALOG_X             0
+#define RETRO_DEVICE_ID_ANALOG_Y             1
 
 /* Id values for MOUSE. */
 #define RETRO_DEVICE_ID_MOUSE_X                0


### PR DESCRIPTION
Added support for analog buttons. Cores can use the new libretro.h constant to request analog input from any RetroPad button. Use the following reference implementation to maintain compatibility with older front-ends.

```
static uint16_t get_analog_button( retro_input_state_t input_state_cb,
                                   int player_index,
                                   int id )
{
    uint16_t button;

    // NOTE: Not all front-ends support analog buttons (or pre-date it) 
    // so we need to handle this in a graceful way.

    // First, try and get an analog value using the new libretro API constant
    button = input_state_cb( player_index,
                             RETRO_DEVICE_ANALOG,
                             RETRO_DEVICE_INDEX_ANALOG_BUTTON,
                             id );

    if ( button == 0 )
    {
        // If we got exactly zero, we're either not pressing the button, or the front-end
        // is not reporting analog values. We need to do a second check using the classic
        // digital API method, to at least get some response - better than nothing.

        // NOTE: If we're honestly just not holding the button, we're still going to get zero.

        button = input_state_cb( player_index,
                                 RETRO_DEVICE_JOYPAD,
                                 0,
                                 id ) ? 0x7FFF : 0;
    }

    return button;
}
```