### PR TITLE
Remove trailing white space.

### DIFF
--- a/audio/dsp_filters/ChipTuneEnhance.dsp
+++ b/audio/dsp_filters/ChipTuneEnhance.dsp
@@ -13,7 +13,7 @@ eq_gains = "6 9 12 7 6 5 7 9 11 6 0"
  reverb_damping = 0.8
  reverb_roomwidth = 0.25
  reverb_roomsize = 0.25
- 
+
 # IIR - filters out some harsh sounds on the upper end
 iir_type = RIAA_CD
 

--- a/audio/dsp_filters/Makefile
+++ b/audio/dsp_filters/Makefile
@@ -64,7 +64,7 @@ asflags := $(ASFLAGS) -fPIC  $(extra_flags)
 objects :=
 
 ifeq (1,$(use_neon))
-   ASMFLAGS := -INEON/asm 
+   ASMFLAGS := -INEON/asm
    asflags += -mfpu=neon
 endif
 

--- a/audio/resampler/drivers/sinc_resampler_neon.S
+++ b/audio/resampler/drivers/sinc_resampler_neon.S
@@ -39,7 +39,7 @@
 process_sinc_neon_asm:
 _process_sinc_neon_asm:
 
-   push {r4, lr}   
+   push {r4, lr}
    vmov.f32 q0, #0.0
    vmov.f32 q8, #0.0
 
@@ -68,7 +68,7 @@ _process_sinc_neon_asm:
    vadd.f32 d16, d16, d17
    vpadd.f32 d0, d0, d16
    vst1.f32 d0, [r0]
-   
+
    pop {r4, pc}
 
 #endif

--- a/glsym/glgen.py
+++ b/glsym/glgen.py
@@ -2,7 +2,7 @@
 
 """
    License statement applies to this file (glgen.py) only.
-""" 
+"""
 
 """
    Permission is hereby granted, free of charge,

--- a/glsym/rglgen.py
+++ b/glsym/rglgen.py
@@ -2,7 +2,7 @@
 
 """
    License statement applies to this file (glgen.py) only.
-""" 
+"""
 
 """
    Permission is hereby granted, free of charge,

--- a/samples/utils/Makefile
+++ b/samples/utils/Makefile
@@ -62,7 +62,7 @@ CC      := $(compiler)
 CXX     := $(subst CC,++,$(compiler))
 flags   := -fPIC $(extra_flags) -I$(LIBRETRO_COMM_DIR)/include
 asflags := -fPIC  $(extra_flags)
-LDFLAGS := 
+LDFLAGS :=
 flags   += -std=c99 -DMD5_BUILD_UTILITY -DSHA1_BUILD_UTILITY
 
 

--- a/streams/file_stream.c
+++ b/streams/file_stream.c
@@ -97,7 +97,7 @@ bool filestream_exists(const char *path)
 
    if (!path || !*path)
       return false;
-   
+
    dummy = filestream_open(path,
          RETRO_VFS_FILE_ACCESS_READ,
          RETRO_VFS_FILE_ACCESS_HINT_NONE);

--- a/vfs/vfs_implementation.c
+++ b/vfs/vfs_implementation.c
@@ -124,10 +124,10 @@ int64_t retro_vfs_file_seek_internal(libretro_vfs_implementation_file *stream, i
 #ifdef HAVE_MMAP
    /* Need to check stream->mapped because this function is
     * called in filestream_open() */
-   if (stream->mapped && stream->hints & 
+   if (stream->mapped && stream->hints &
          RETRO_VFS_FILE_ACCESS_HINT_FREQUENT_ACCESS)
    {
-      /* fseek() returns error on under/overflow but 
+      /* fseek() returns error on under/overflow but
        * allows cursor > EOF for
          read-only file descriptors. */
       switch (whence)


### PR DESCRIPTION
This was accomplished with this command.
```
find . -type f -not -iwholename '*.git*' -exec sed -i 's/[ \t]*$//' {} \;
```
Given that libretro-common could end up in other repos I thought it would be good to remove these trailing white spaces at the source. Surprisingly there weren't very many of them.