### PR TITLE
add character versions of path_default_slash

### DIFF
--- a/include/file/file_path.h
+++ b/include/file/file_path.h
@@ -432,7 +432,7 @@ void path_basedir_wrapper(char *path);
 #endif
 
 /**
- * path_default_slash:
+ * path_default_slash and path_default_slash_c:
  *
  * Gets the default slash separator.
  *
@@ -440,8 +440,10 @@ void path_basedir_wrapper(char *path);
  */
 #ifdef _WIN32
 #define path_default_slash() "\\"
+#define path_default_slash_c() '\\'
 #else
 #define path_default_slash() "/"
+#define path_default_slash_c() '/'
 #endif
 
 /**


### PR DESCRIPTION
I find myself usually needing the slash as a char.

As things are I can use`path_default_slash()[0]` but I wondered if having a character version might be useful.