### PR TITLE
clarify that core options may be set by the core again

### DIFF
--- a/include/libretro.h
+++ b/include/libretro.h
@@ -599,9 +599,12 @@ enum retro_mod
                                             * GET_VARIABLE.
                                             * This allows the frontend to present these variables to
                                             * a user dynamically.
-                                            * This should be called as early as possible (ideally in
-                                            * retro_set_environment).
-                                            *
+                                            * This should be called the first time as early as
+                                            * possible (ideally in retro_set_environment).
+                                            * Afterward it may be called again for the core to communicate
+                                            * updated options to the frontend, but the number of core
+                                            * options must not change from the number in the initial call.
+					    *
                                             * 'data' points to an array of retro_variable structs
                                             * terminated by a { NULL, NULL } element.
                                             * retro_variable::key should be namespaced to not collide


### PR DESCRIPTION
Based on this existing language I falsely concluded that I would not be able to set core options again from within the core code once I had set them for the first time and `retro_run` was going.

This language I believe more accurately reflects how the API works but please correct any of my misunderstandings. The warning about changing the number of core options comes from https://github.com/libretro/RetroArch/issues/6371

Thanks also to radius for educating me on this 