### PR TITLE
fix return of path_remove_extension

### DIFF
--- a/file/file_path.c
+++ b/file/file_path.c
@@ -392,7 +392,7 @@ char *path_remove_extension(char *path)
       return NULL;
    if (*last)
       *last = '\0';
-   return last;
+   return path;
 }
 
 /**


### PR DESCRIPTION
According to the docs/comment, path_remove_extension should return the "path with the extension part removed."

Currently this function is returning the extension itself, rather than the path.