### PR TITLE
path_remove_extension should return original path when there is no extension

### DIFF
--- a/file/file_path.c
+++ b/file/file_path.c
@@ -383,15 +383,16 @@ const char *path_get_extension(const char *path)
  * Only '.'s after the last slash are considered.
  *
  * Returns: path with the extension part removed.
+ * If there is no extension at the end of path,
+ * returns a pointer to the unaltered original path.
  */
 char *path_remove_extension(char *path)
 {
    char *last = !string_is_empty(path) 
       ? (char*)strrchr(path_basename(path), '.') : NULL;
    if (!last)
-      return NULL;
-   if (*last)
-      *last = '\0';
+      return path;
+   *last = '\0';
    return path;
 }
 


### PR DESCRIPTION
This is how things currently work:

* If `path_remove_extension` is provided a path with an extension such as `/storage/game.zip`, it returns `/storage/game` -- the expected behavior
* if `path_remove_extension` is provided a path that already has no extension such as `/storage/game` it returns `NULL` -- not what I was expecting

This PR changes the outcome of the second scenario so that it also returns `/storage/game`. I believe this is also more consistent with the behavior of other functions in this library.