### PR TITLE
correct path_remove_extension docs

### DIFF
--- a/file/file_path.c
+++ b/file/file_path.c
@@ -378,13 +378,15 @@ const char *path_get_extension(const char *path)
  * path_remove_extension:
  * @path               : path
  *
- * Removes the extension from the path and returns the result.
- * Removes all text after and including the last '.'.
+ * Mutates path by removing its extension. Removes all
+ * text after and including the last '.'.
  * Only '.'s after the last slash are considered.
  *
- * Returns: path with the extension part removed.
- * If there is no extension at the end of path,
- * returns a pointer to the unaltered original path.
+ * Returns: 
+ * 1) If path has an extension, returns path with the
+ *    extension removed.
+ * 2) If there is no extension, returns NULL.
+ * 3) If path is empty or NULL, returns NULL
  */
 char *path_remove_extension(char *path)
 {

--- a/include/file/file_path.h
+++ b/include/file/file_path.h
@@ -100,11 +100,15 @@ const char *path_get_extension(const char *path);
  * path_remove_extension:
  * @path               : path
  *
- * Removes the extension from the path and returns the result.
- * Removes all text after and including the last '.'.
+ * Mutates path by removing its extension. Removes all
+ * text after and including the last '.'.
  * Only '.'s after the last slash are considered.
  *
- * Returns: path with the extension part removed.
+ * Returns: 
+ * 1) If path has an extension, returns path with the
+ *    extension removed.
+ * 2) If there is no extension, returns NULL.
+ * 3) If path is empty or NULL, returns NULL
  */
 char *path_remove_extension(char *path);
 


### PR DESCRIPTION
The important correction is that if the `path` string has no extension, then `path_remove_extension()` **does not** return "a pointer to the unaltered original path" as the docs currently say.

In that case  `path_remove_extension()` returns `NULL`.