### PR TITLE
when need_fullpath is false, retro_game_info::path contains the content filename

### DIFF
--- a/include/libretro.h
+++ b/include/libretro.h
@@ -2209,7 +2209,8 @@ struct retro_system_info
     *    - retro_game_info::data and retro_game_info::size are invalid
     *
     * If need_fullpath is false and retro_load_game() is called:
-    *    - retro_game_info::path may be NULL
+    *    - retro_game_info::path will contain the filename of the content
+    *      being loaded (ie the basename of the content)
     *    - retro_game_info::data and retro_game_info::size are guaranteed
     *      to be valid
     *

--- a/include/libretro.h
+++ b/include/libretro.h
@@ -2210,9 +2210,13 @@ struct retro_system_info
     *
     * If need_fullpath is false and retro_load_game() is called:
     *    - retro_game_info::path will contain the filename of the content
-    *      being loaded (ie the basename of the content)
+    *      being loaded (ie the basename of the content).
     *    - retro_game_info::data and retro_game_info::size are guaranteed
     *      to be valid
+    *    - Note: Historically frontends were not guaranteed to return a
+    *      path or filename when need_fullpath is false. Cores needing
+    *      to remain compatible with legacy frontends should ensure that
+    *      retro_game_info::path is valid.
     *
     * See also: 
     *    - RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY


### PR DESCRIPTION
Note: AFAIK there is no reason to suspect that this change would affect any existing core or frontend implementations, because retro_game_info::path is currently not guaranteed to have any particular contents when need_fullpath is false.

If accepted, this proposal would mean that moving forward frontends would set retro_game_info::path to the filename (aka basename) of the content being loaded.

My previous PR helped clarify the existing behavior of RetroArch with regards to the value of `retro_game_info::path` when `need_fullpath == false`. There is now consensus that this part of the documentation accurately describes the way RA works.

This PR is my attempt to express the proposal that is currently being discussed in the beetle-gba discussion where this all started: https://github.com/libretro/beetle-gba-libretro/pull/33. I hope that it will be helpful.



