### PR TITLE
Fix fscanf drop-in replacement

### DIFF
--- a/include/streams/file_stream_transforms.h
+++ b/include/streams/file_stream_transforms.h
@@ -47,6 +47,7 @@ RETRO_BEGIN_DECLS
 #undef fprintf
 #undef ferror
 #undef feof
+#undef fscanf
 
 #define fopen rfopen
 #define fclose rfclose
@@ -61,6 +62,7 @@ RETRO_BEGIN_DECLS
 #define fprintf rfprintf
 #define ferror rferror
 #define feof rfeof
+#define fscanf rfscanf
 
 #endif
 

--- a/include/streams/file_stream_transforms.h
+++ b/include/streams/file_stream_transforms.h
@@ -92,6 +92,8 @@ int rferror(RFILE* stream);
 
 int rfeof(RFILE* stream);
 
+int rfscanf(RFILE * stream, const char * format, ...);
+
 RETRO_END_DECLS
 
 #endif

--- a/streams/file_stream_transforms.c
+++ b/streams/file_stream_transforms.c
@@ -109,7 +109,7 @@ char *rfgets(char *buffer, int maxCount, RFILE* stream)
 
 int rfgetc(RFILE* stream)
 {
-	return filestream_getc(stream);
+   return filestream_getc(stream);
 }
 
 int64_t rfwrite(void const* buffer,
@@ -131,11 +131,11 @@ int64_t rfflush(RFILE * stream)
 int rfprintf(RFILE * stream, const char * format, ...)
 {
    int result;
-	va_list vl;
-	va_start(vl, format);
-	result = filestream_vprintf(stream, format, vl);
-	va_end(vl);
-	return result;
+   va_list vl;
+   va_start(vl, format);
+   result = filestream_vprintf(stream, format, vl);
+   va_end(vl);
+   return result;
 }
 
 int rferror(RFILE* stream)
@@ -146,4 +146,14 @@ int rferror(RFILE* stream)
 int rfeof(RFILE* stream)
 {
    return filestream_eof(stream);
+}
+
+int rfscanf(RFILE * stream, const char * format, ...)
+{
+   int result;
+   va_list vl;
+   va_start(vl, format);
+   result = filestream_scanf(stream, format, vl);
+   va_end(vl);
+   return result;
 }


### PR DESCRIPTION
I used `rfprintf` as a base, because arguments were the same