### PR TITLE
fix glgen scripts being unable to parse gl functions defined over mutiple lines

### DIFF
--- a/glsym/glgen.py
+++ b/glsym/glgen.py
@@ -33,6 +33,25 @@ def noext(sym):
          return False
    return True
 
+def fix_multiline_functions(lines):
+   fixed_lines = []
+   temp_lines = []
+   for line in lines:
+      if line.count('(') > line.count(')'):
+         temp_lines.append(line)
+      else:
+         if len(temp_lines) > 0:
+            if line.count(')') > line.count('('):
+               temp_lines.append(line)
+               fixed_line = re.sub(' +',' ', ''.join(temp_lines).replace('\n','').replace('\t',''))
+               fixed_lines.append(fixed_line)
+               temp_lines = []
+            else:
+               temp_lines.append(line)
+         else:
+            fixed_lines.append(line)
+   return fixed_lines
+
 def find_gl_symbols(lines):
    typedefs = []
    syms = []
@@ -68,7 +87,7 @@ if __name__ == '__main__':
          banned_ext.append(banned)
 
    with open(sys.argv[1], 'r') as f:
-      lines = f.readlines()
+      lines = fix_multiline_functions(f.readlines())
       typedefs, syms = find_gl_symbols(lines)
 
       overrides = generate_defines(syms)

--- a/glsym/rglgen.py
+++ b/glsym/rglgen.py
@@ -33,6 +33,25 @@ def noext(sym):
          return False
    return True
 
+def fix_multiline_functions(lines):
+   fixed_lines = []
+   temp_lines = []
+   for line in lines:
+      if line.count('(') > line.count(')'):
+         temp_lines.append(line)
+      else:
+         if len(temp_lines) > 0:
+            if line.count(')') > line.count('('):
+               temp_lines.append(line)
+               fixed_line = re.sub(' +',' ', ''.join(temp_lines).replace('\n','').replace('\t',''))
+               fixed_lines.append(fixed_line)
+               temp_lines = []
+            else:
+               temp_lines.append(line)
+         else:
+            fixed_lines.append(line)
+   return fixed_lines
+
 def find_gl_symbols(lines):
    typedefs = []
    syms = []
@@ -68,7 +87,7 @@ if __name__ == '__main__':
          banned_ext.append(banned)
 
    with open(sys.argv[1], 'r') as f:
-      lines = f.readlines()
+      lines = fix_multiline_functions(f.readlines())
       typedefs, syms = find_gl_symbols(lines)
 
       overrides = generate_defines(syms)

--- a/glsym/xglgen.py
+++ b/glsym/xglgen.py
@@ -33,6 +33,25 @@ def noext(sym):
          return False
    return True
 
+def fix_multiline_functions(lines):
+   fixed_lines = []
+   temp_lines = []
+   for line in lines:
+      if line.count('(') > line.count(')'):
+         temp_lines.append(line)
+      else:
+         if len(temp_lines) > 0:
+            if line.count(')') > line.count('('):
+               temp_lines.append(line)
+               fixed_line = re.sub(' +',' ', ''.join(temp_lines).replace('\n','').replace('\t',''))
+               fixed_lines.append(fixed_line)
+               temp_lines = []
+            else:
+               temp_lines.append(line)
+         else:
+            fixed_lines.append(line)
+   return fixed_lines
+
 def find_gl_symbols(lines):
    typedefs = []
    syms = []
@@ -69,7 +88,7 @@ if __name__ == '__main__':
          banned_ext.append(banned)
 
    with open(sys.argv[1], 'r') as f:
-      lines = f.readlines()
+      lines = fix_multiline_functions(f.readlines())
       typedefs, syms = find_gl_symbols(lines)
 
       overrides = generate_defines(syms)


### PR DESCRIPTION
While attempting to port a core to the switch I noticed a lot of core gl functions were missing. After investigating I noticed that all of these functions were defined over multiple lines. After checking the glgen scripts I noticed that they run a regex on every line, making it unable to capture multi line function definitions.

I assume this is not intended behavior.