### PR TITLE
add gzFile_s stuct to zlib.h

### DIFF
--- a/include/compat/zlib.h
+++ b/include/compat/zlib.h
@@ -1661,6 +1661,13 @@ uint32_t adler32 (uint32_t adler, const uint8_t *buf, size_t len);
 
 #ifndef Z_SOLO
 
+struct gzFile_s
+{
+   unsigned have;
+   unsigned char *next;
+   z_off64_t pos;
+};
+
 /* gzgetc() macro and its supporting function and exposed data structure.  Note
  * that the real internal state is much larger than the exposed structure.
  * This abbreviated structure exposes just enough for the gzgetc() macro.  The


### PR DESCRIPTION
This struct is a standard part of zlib.h -- it seems to be missing here which is causing problems as I try to migrate MAME 2003 from its own version of zlib to **libretro-deps/libz** which refers to this zlib.h.

Here you can see it in madler/zlib: https://github.com/madler/zlib/blob/master/zlib.h#L1817-L1821