### PR TITLE
split sha1.h from sha1.c

### DIFF
--- a/include/utils/sha1.h
+++ b/include/utils/sha1.h
@@ -1,0 +1,62 @@
+/*
+ *  sha1.h
+ *
+ *  Copyright (C) 1998, 2009
+ *  Paul E. Jones <paulej@packetizer.com>
+ *  All Rights Reserved
+ *
+ *****************************************************************************
+ *  $Id: sha1.h 12 2009-06-22 19:34:25Z paulej $
+ *****************************************************************************
+ *
+ *  Description:
+ *      This class implements the Secure Hashing Standard as defined
+ *      in FIPS PUB 180-1 published April 17, 1995.
+ *
+ *      Many of the variable names in the SHA1Context, especially the
+ *      single character names, were used because those were the names
+ *      used in the publication.
+ *
+ *      Please read the file sha1.c for more information.
+ *
+ */
+
+#include <stdio.h>
+#include <string.h>
+#ifdef WIN32
+#include <io.h>
+#endif
+#include <fcntl.h>
+#include <string/stdstring.h>
+
+#ifndef _SHA1_H_
+#define _SHA1_H_
+
+/*
+ *  This structure will hold context information for the hashing
+ *  operation
+ */
+typedef struct SHA1Context
+{
+   unsigned Message_Digest[5]; /* Message Digest (output)          */
+
+   unsigned Length_Low;        /* Message length in bits           */
+   unsigned Length_High;       /* Message length in bits           */
+
+   unsigned char Message_Block[64]; /* 512-bit message blocks      */
+   int Message_Block_Index;    /* Index into message block array   */
+
+   int Computed;               /* Is the digest computed?          */
+   int Corrupted;              /* Is the message digest corruped?  */
+} SHA1Context;
+
+/*
+ *  Function Prototypes
+ */
+void SHA1Reset(SHA1Context *);
+int SHA1Result(SHA1Context *);
+void SHA1Input( SHA1Context *,
+      const unsigned char *,
+      unsigned);
+
+#endif

--- a/utils/sha1.c
+++ b/utils/sha1.c
@@ -1,67 +1,4 @@
 /*
- *  sha1.h
- *
- *  Copyright (C) 1998, 2009
- *  Paul E. Jones <paulej@packetizer.com>
- *  All Rights Reserved
- *
- *****************************************************************************
- *  $Id: sha1.h 12 2009-06-22 19:34:25Z paulej $
- *****************************************************************************
- *
- *  Description:
- *      This class implements the Secure Hashing Standard as defined
- *      in FIPS PUB 180-1 published April 17, 1995.
- *
- *      Many of the variable names in the SHA1Context, especially the
- *      single character names, were used because those were the names
- *      used in the publication.
- *
- *      Please read the file sha1.c for more information.
- *
- */
-
-#include <stdio.h>
-#include <string.h>
-#ifdef WIN32
-#include <io.h>
-#endif
-#include <fcntl.h>
-#include <string/stdstring.h>
-
-#ifndef _SHA1_H_
-#define _SHA1_H_
-
-/*
- *  This structure will hold context information for the hashing
- *  operation
- */
-typedef struct SHA1Context
-{
-   unsigned Message_Digest[5]; /* Message Digest (output)          */
-
-   unsigned Length_Low;        /* Message length in bits           */
-   unsigned Length_High;       /* Message length in bits           */
-
-   unsigned char Message_Block[64]; /* 512-bit message blocks      */
-   int Message_Block_Index;    /* Index into message block array   */
-
-   int Computed;               /* Is the digest computed?          */
-   int Corrupted;              /* Is the message digest corruped?  */
-} SHA1Context;
-
-/*
- *  Function Prototypes
- */
-void SHA1Reset(SHA1Context *);
-int SHA1Result(SHA1Context *);
-void SHA1Input( SHA1Context *,
-      const unsigned char *,
-      unsigned);
-
-#endif
-
-/*
  *  sha1.c
  *
  *  Copyright (C) 1998, 2009
@@ -101,7 +38,7 @@ void SHA1Input( SHA1Context *,
  *
  */
 
-/*#include "sha1.h"*/
+#include <utils/sha1.h>
 
 /*
  *  Define the circular shift macro


### PR DESCRIPTION
I'm interested in migrating from the legacy MAME 0.78 SHA1 implementation to the one in libretro-common. The issue is that the header and the implementation are collapsed into one source file.

Is there any reason why these two files can't exist separately in a more typical arrangement?