### PR TITLE
point recursive zlib includes to libretro-common

### DIFF
--- a/include/compat/zlib.h
+++ b/include/compat/zlib.h
@@ -1765,7 +1765,7 @@ const uint32_t * get_crc_table(void);
 #endif /* ZLIB_H */
 
 #else
-#include <zlib.h>
+#include <compat/zlib.h>
 #endif
 
 #endif

--- a/include/compat/zutil.h
+++ b/include/compat/zutil.h
@@ -247,7 +247,7 @@ extern char z_errmsg[10][21]; /* indexed by 2-zlib_error */
 #endif /* ZUTIL_H */
 
 #else
-#include <zutil.h>
+#include <compat/zutil.h>
 #endif
 
 #endif


### PR DESCRIPTION
In the RetroArch msys2 environment, this change helps make sure that the recursive includes correctly find themselves rather than pulling in a different zlib implementation.

Other `zlib.h` and `zutil.h` includes throughtout libretro-common already specify `compat/` as part of their path -- this uses the same approach for the recursion.