### PR TITLE
Allow "private" gl symbol loader

### DIFF
--- a/include/glsym/glsym.h
+++ b/include/glsym/glsym.h
@@ -38,4 +38,8 @@
 #endif
 #endif
 
+#ifdef HAVE_GLSYM_PRIVATE
+#include "glsym_private.h"
+#endif
+
 #endif


### PR DESCRIPTION
So, with the yabasanshiro libretro core, i can't use glsm on android without adding some definition to glsm.

The first idea was to apply this patch : https://pastebin.com/raw/gGuYwbnz , however it would end up disappearing if someone decided to regenerate those files

The second idea was to generate `glsym_es31.h` and `glsym_es31.c` by running glgen.py on `GLES3/gl31.h`, but the generated files didn't end up well (i had to tinker with them to build the core, and when it finally built, it crashed)

That's why i came up with this third solution : it allows the developper to add his own gl symbol by simply defining `HAVE_GLSYM_PRIVATE` and having a file named `glsym_private.h` in the include dirs, it works well, is flexible, and is less intrusive than the other solutions.

As a proof of concept i managed to deal with all my issues by creating the following files : 
- glsym_private.h : 
```
#ifndef RGLGEN_PRIV_DECL_H__
#define RGLGEN_PRIV_DECL_H__
#ifdef __cplusplus
extern "C" {
#endif

typedef double GLclampd;
typedef double GLdouble;
typedef void (GL_APIENTRYP RGLSYMGLMEMORYBARRIERPROC) (GLbitfield barriers);

#define glMemoryBarrier __rglgen_glMemoryBarrier

#define GL_PATCHES                        0x000E
#define GL_FRAMEBUFFER_BARRIER_BIT        0x00000400
#define GL_TEXTURE_UPDATE_BARRIER_BIT     0x00000100
#define GL_TEXTURE_FETCH_BARRIER_BIT      0x00000008
#define GL_TESS_CONTROL_SHADER            0x8E88
#define GL_TESS_EVALUATION_SHADER         0x8E87
#define GL_GEOMETRY_SHADER                0x8DD9

extern RGLSYMGLMEMORYBARRIERPROC __rglgen_glMemoryBarrier;

#ifdef __cplusplus
}
#endif
#endif
```
- glsym_private.c : 
```
#include "glsym/glsym.h"

RGLSYMGLMEMORYBARRIERPROC __rglgen_glMemoryBarrier;
```