### PR TITLE
RFC: core based netplay passthrough

### DIFF
--- a/include/libretro.h
+++ b/include/libretro.h
@@ -1087,6 +1087,14 @@ enum retro_mod
                                             * The core can use the returned value to set an ideal 
                                             * refresh rate/framerate.
                                             */
+#define RETRO_ENVIRONMENT_SET_NETPLAY_PASSTHROUGH (51 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* const bool * --
+                                            * If true, the libretro implementation supports netplay on it's own,
+                                            * this indicates the frontend to leverage that instead of using
+                                            * the frontend specific netplay implementation
+                                            *
+                                            * This must be called in retro_init
+                                            */
 
 /* VFS functionality */
 
@@ -2526,6 +2534,18 @@ RETRO_API unsigned retro_get_region(void);
 /* Gets region of memory. */
 RETRO_API void *retro_get_memory_data(unsigned id);
 RETRO_API size_t retro_get_memory_size(unsigned id);
+
+/* Start hosting a game */
+RETRO_API bool retro_netplay_host_start(const char *hostname, unsigned port);
+
+/* Connect to a netplay peer */
+RETRO_API bool retro_netplay_host_connect(const char *hostname, unsigned port);
+
+/* Stop hosting a game */
+RETRO_API bool retro_netplay_host_stop(void);
+
+/* Disconnect from a netplay peer */
+RETRO_API bool retro_netplay_host_discconnect(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is something I had been thinking about for a while, and a user seemed interested too.
So much that he started a bounty.

https://github.com/fr500/dosbox-svn/issues/6
https://www.bountysource.com/issues/72009314-make-ipxnet-avaible-just-by-using-netplay

This is a first draft of what it would take to have such integration.
I'd like some comments before starting to work on a final proposal for a core (dosbox) and the frontend (retroarch of course)

This would be ideal for game cores, and I figure with some work it would work for dolphin/ppsspp netplay too.

The idea would be that when the env is set the "start netplay" action in the frontend defers to a different codepath, it would still announce the lobby, but instead of implementing netplay, it would signal the core to start in server mode. The frontend specifies the port and the listening address. Maybe some other variables would be desirable, I'd like to hear other people's opinions.

A "join host" action in the frontend would then signal the core to join the hosting peer.

I already tried this in a hacky manner (hijacked the lan announcement code) and it worked reasonably well. Relay would not be supported of course, but port mapping should)