### PR TITLE
backport stuff from flycast

### DIFF
--- a/include/glsm/glsm.h
+++ b/include/glsm/glsm.h
@@ -32,9 +32,6 @@
 RETRO_BEGIN_DECLS
 
 #ifdef HAVE_OPENGLES2
-#if !defined(ANDROID)
-typedef GLfloat GLdouble;
-#endif
 typedef GLclampf GLclampd;
 #endif
 

--- a/include/glsm/glsmsym.h
+++ b/include/glsm/glsmsym.h
@@ -25,6 +25,10 @@
 
 #include <glsm/glsm.h>
 
+#ifdef HAVE_GLSYM_PRIVATE
+#include "glsym_private.h"
+#endif
+
 #include <retro_common_api.h>
 
 RETRO_BEGIN_DECLS

--- a/include/rthreads/rthreads.h
+++ b/include/rthreads/rthreads.h
@@ -132,6 +132,15 @@ void slock_free(slock_t *lock);
 void slock_lock(slock_t *lock);
 
 /**
+ * slock_try_lock:
+ * @lock                    : pointer to mutex object
+ *
+ * Attempts to lock a mutex. If a mutex is already locked by
+ * another thread, return false.  If the lock is acquired, return true.
+**/
+bool slock_try_lock(slock_t *lock);
+
+/**
  * slock_unlock:
  * @lock                    : pointer to mutex object
  *

--- a/rthreads/rthreads.c
+++ b/rthreads/rthreads.c
@@ -386,6 +386,24 @@ void slock_lock(slock_t *lock)
 }
 
 /**
+ * slock_try_lock:
+ * @lock                    : pointer to mutex object
+ *
+ * Attempts to lock a mutex. If a mutex is already locked by
+ * another thread, return false.  If the lock is acquired, return true.
+**/
+bool slock_try_lock(slock_t *lock)
+{
+   if (!lock)
+      return false;
+#ifdef USE_WIN32_THREADS
+   return TryEnterCriticalSection(&lock->lock);
+#else
+   return pthread_mutex_trylock(&lock->lock)==0;
+#endif
+}
+
+/**
  * slock_unlock:
  * @lock                    : pointer to mutex object
  *


### PR DESCRIPTION
Removing GLdouble seems right, until a more proper fix is found i recommend using the `HAVE_GLSYM_PRIVATE` stuff to handle the issue on a per-target basis when device's gles implementation is missing it (see https://github.com/libretro/flycast/blob/master/core/libretro/glsym_private.h)