### PR TITLE
proper fix for the GLdouble issue

### DIFF
--- a/include/glsm/glsm.h
+++ b/include/glsm/glsm.h
@@ -32,7 +32,8 @@
 RETRO_BEGIN_DECLS
 
 #ifdef HAVE_OPENGLES2
-typedef GLclampf GLclampd;
+typedef double GLdouble;
+typedef double GLclampd;
 #endif
 
 #if defined(HAVE_OPENGLES2)


### PR DESCRIPTION
Build won't fail if we sync those typedef with the ones from Khronos headers