### PR TITLE
fix filestream_getc and filestream_putc semantics

### DIFF
--- a/streams/file_stream.c
+++ b/streams/file_stream.c
@@ -204,9 +204,9 @@ int filestream_getc(RFILE *stream)
 {
    char c = 0;
    if (!stream)
-      return 0;
-   if(filestream_read(stream, &c, 1) == 1)
-      return (int)c;
+      return EOF;
+   if (filestream_read(stream, &c, 1) == 1)
+      return (int)(unsigned char)c;
    return EOF;
 }
 
@@ -427,7 +427,7 @@ int filestream_putc(RFILE *stream, int c)
    char c_char = (char)c;
    if (!stream)
       return EOF;
-   return filestream_write(stream, &c_char, 1)==1 ? c : EOF;
+   return filestream_write(stream, &c_char, 1)==1 ? (int)(unsigned char)c : EOF;
 }
 
 int filestream_vprintf(RFILE *stream, const char* format, va_list args)


### PR DESCRIPTION
`int filestream_getc(RFILE *stream)` would

 - return 0 if `stream` is `NULL` but also when a 0 byte is read
 - if `char` is `signed`, potentially return `EOF` when reading a byte with the same value (typically -1)

Which means that error/`EOF` checking will have false positives.
This also affects `filestream_gets` and `filestream_getline` as they use `filestream_getc`.

`int filestream_putc(RFILE *stream, int c)` has the same issue of returning negative written bytes.

This PR changes both functions to be more in line with the C analogs [fgetc](https://en.cppreference.com/w/c/io/fgetc) and [fputc](https://en.cppreference.com/w/c/io/fputc), i.e.

 - return `EOF` in any error case
 - return written bytes as an `unsigned char`