### PR TITLE
Core options updates/clarifications

### DIFF
--- a/include/libretro.h
+++ b/include/libretro.h
@@ -1117,7 +1117,7 @@ enum retro_mod
                                             * This may be still be done regardless of the core options
                                             * interface version.
                                             *
-                                            * If version is 1 however, core options may instead be set by
+                                            * If version is >= 1 however, core options may instead be set by
                                             * passing an array of retro_core_option_definition structs to
                                             * RETRO_ENVIRONMENT_SET_CORE_OPTIONS, or a 2D array of
                                             * retro_core_option_definition structs to RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL.
@@ -1132,8 +1132,8 @@ enum retro_mod
                                             * GET_VARIABLE.
                                             * This allows the frontend to present these variables to
                                             * a user dynamically.
-                                            * This should only be called if RETRO_ENVIRONMENT_GET_ENHANCED_CORE_OPTIONS
-                                            * returns an API version of 1.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 1.
                                             * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
                                             * This should be called the first time as early as
                                             * possible (ideally in retro_set_environment).
@@ -1194,8 +1194,8 @@ enum retro_mod
                                             * GET_VARIABLE.
                                             * This allows the frontend to present these variables to
                                             * a user dynamically.
-                                            * This should only be called if RETRO_ENVIRONMENT_GET_ENHANCED_CORE_OPTIONS
-                                            * returns an API version of 1.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 1.
                                             * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
                                             * This should be called the first time as early as
                                             * possible (ideally in retro_set_environment).
@@ -2501,7 +2501,21 @@ struct retro_core_option_display
    bool visible;
 };
 
-/* Maximum number of values permitted for a core option */
+/* Maximum number of values permitted for a core option
+ * > Note: We have to set a maximum value due the limitations
+ *   of the C language - i.e. it is not possible to create an
+ *   array of structs each containing a variable sized array,
+ *   so the retro_core_option_definition values array must
+ *   have a fixed size. The size limit of 128 is a balancing
+ *   act - it needs to be large enough to support all 'sane'
+ *   core options, but setting it too large may impact low memory
+ *   platforms. In practise, if a core option has more than
+ *   128 values then the implementation is likely flawed.
+ *   To quote the above API reference:
+ *      "The number of possible options should be very limited
+ *       i.e. it should be feasible to cycle through options
+ *       without a keyboard."
+ */
 #define RETRO_NUM_CORE_OPTION_VALUES_MAX 128
 
 struct retro_core_option_value

--- a/samples/core_options/example_default/libretro_core_options.h
+++ b/samples/core_options/example_default/libretro_core_options.h
@@ -7,6 +7,19 @@
 #include <libretro.h>
 #include <retro_inline.h>
 
+/*
+ ********************************
+ * VERSION: 1.2
+ ********************************
+ *
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -152,7 +165,7 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
    if (!environ_cb)
       return;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version == 1))
+   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version >= 1))
    {
       struct retro_core_options_intl core_options_intl;
       unsigned language = 0;
@@ -223,7 +236,7 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
             }
 
             /* Build values string */
-            if (num_values > 1)
+            if (num_values > 0)
             {
                size_t j;
 
@@ -255,7 +268,7 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
          variables[i].key   = key;
          variables[i].value = values_buf[i];
       }
-      
+
       /* Set variables */
       environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
 

--- a/samples/core_options/example_hide_option/libretro_core_options.h
+++ b/samples/core_options/example_hide_option/libretro_core_options.h
@@ -7,6 +7,19 @@
 #include <libretro.h>
 #include <retro_inline.h>
 
+/*
+ ********************************
+ * VERSION: 1.2
+ ********************************
+ *
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -167,7 +180,7 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
    if (!environ_cb)
       return;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version == 1))
+   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version >= 1))
    {
       struct retro_core_options_intl core_options_intl;
       unsigned language = 0;
@@ -249,7 +262,7 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
             }
 
             /* Build values string */
-            if (num_values > 1)
+            if (num_values > 0)
             {
                size_t j;
 
@@ -282,7 +295,7 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
          variables[option_index].value = values_buf[i];
          option_index++;
       }
-      
+
       /* Set variables */
       environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
 

--- a/samples/core_options/example_translation/libretro_core_options.h
+++ b/samples/core_options/example_translation/libretro_core_options.h
@@ -7,6 +7,19 @@
 #include <libretro.h>
 #include <retro_inline.h>
 
+/*
+ ********************************
+ * VERSION: 1.2
+ ********************************
+ *
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -187,7 +200,7 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
    if (!environ_cb)
       return;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version == 1))
+   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version >= 1))
    {
       struct retro_core_options_intl core_options_intl;
       unsigned language = 0;
@@ -258,7 +271,7 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
             }
 
             /* Build values string */
-            if (num_values > 1)
+            if (num_values > 0)
             {
                size_t j;
 
@@ -290,7 +303,7 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
          variables[i].key   = key;
          variables[i].value = values_buf[i];
       }
-      
+
       /* Set variables */
       environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
 


### PR DESCRIPTION
Following developer feedback, this PR makes some very slight changes to v1 core options API reference comments, and to the provided `libretro_core_options.h` examples:

- In `libretro.h`, comments have been updated to reflect the fact that the core options v1 interface should be supported if `RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION` is >= 1 (previously, the comments indicated that core options v1 would only be supported if `RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION` == 1)

- In `libretro.h`, and explanation of the `RETRO_NUM_CORE_OPTION_VALUES_MAX` define is provided (at least one dev has queried this)

- The `libretro_core_options.h` samples now include a 'version' header comment, including a changelog (so we can keep track of updates)

- The `libretro_core_options.h` samples now use the core options v1 interface if `RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION` is >= 1 (to match the `libretro.h` API comments)

- The `libretro_core_options.h` samples now support the generation of fallback core options v0 retro variable arrays containing options with a single value. I still maintain that options with a single value are erroneous, and should be treated as such, but I guess we shouldn't impose rules that may impact poorly designed cores that currently work with the v0 interface...

Side note: These changes don't really affect any existing cores that have been updated with 'enhanced' core options, but the `RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION` is >= 1 check may become relevant when libretro API v2.0 is released. So there is no need to change any existing core code at present, but all cores should be reviewed as part of the roll-out of libretro API v2.0 (whenever that happens).