### PR TITLE
Fix warnings about redefining __STDC_FORMAT_MACROS

### DIFF
--- a/include/retro_common_api.h
+++ b/include/retro_common_api.h
@@ -89,7 +89,9 @@ typedef int ssize_t;
 /* C++11 says this one isn't needed, but apparently (some versions of) mingw require it anyways */
 /* https://stackoverflow.com/questions/8132399/how-to-printf-uint64-t-fails-with-spurious-trailing-in-format */
 /* https://github.com/libretro/RetroArch/issues/6009 */
-#define __STDC_FORMAT_MACROS
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS 1
+#endif
 #include <inttypes.h>
 #endif
 #ifndef PRId64


### PR DESCRIPTION
It's not clear whether `__STDC_FORMAT_MACROS`  can already be defined as an empty macro, or as 1. This results in compilation warning on some platforms (mingw under Linux for example.)

Only define it if not already defined, and define it to 1 instead of as an empty macro.