### PR TITLE
Single docstring for license

### DIFF
--- a/glsym/glgen.py
+++ b/glsym/glgen.py
@@ -2,9 +2,7 @@
 
 """
    License statement applies to this file (glgen.py) only.
-"""
 
-"""
    Permission is hereby granted, free of charge,
    to any person obtaining a copy of this software and associated documentation files (the "Software"),
    to deal in the Software without restriction, including without limitation the rights to

--- a/glsym/rglgen.py
+++ b/glsym/rglgen.py
@@ -2,9 +2,7 @@
 
 """
    License statement applies to this file (glgen.py) only.
-"""
 
-"""
    Permission is hereby granted, free of charge,
    to any person obtaining a copy of this software and associated documentation files (the "Software"),
    to deal in the Software without restriction, including without limitation the rights to

--- a/glsym/xglgen.py
+++ b/glsym/xglgen.py
@@ -2,9 +2,7 @@
 
 """
    License statement applies to this file (xglgen.py) only.
-"""
 
-"""
    Permission is hereby granted, free of charge,
    to any person obtaining a copy of this software and associated documentation files (the "Software"),
    to deal in the Software without restriction, including without limitation the rights to


### PR DESCRIPTION
Python convention expects a single main docstring per file.