### PR TITLE
retro_endianness: Replace swap macros with inline functions

### DIFF
--- a/include/retro_endianness.h
+++ b/include/retro_endianness.h
@@ -31,38 +31,47 @@
 #define SWAP16 _byteswap_ushort
 #define SWAP32 _byteswap_ulong
 #else
-#define SWAP16(x) ((uint16_t)(                  \
-         (((uint16_t)(x) & 0x00ff) << 8)      | \
-         (((uint16_t)(x) & 0xff00) >> 8)        \
-          ))
-#define SWAP32(x) ((uint32_t)(           \
-         (((uint32_t)(x) & 0x000000ff) << 24) | \
-         (((uint32_t)(x) & 0x0000ff00) <<  8) | \
-         (((uint32_t)(x) & 0x00ff0000) >>  8) | \
-         (((uint32_t)(x) & 0xff000000) >> 24)   \
-         ))
+static INLINE uint16_t SWAP16(uint16_t x)
+{
+  return ((x & 0x00ff) << 8) |
+         ((x & 0xff00) >> 8);
+}
+
+static INLINE uint32_t SWAP32(uint32_t x)
+{
+  return ((x & 0x000000ff) << 24) |
+         ((x & 0x0000ff00) <<  8) |
+         ((x & 0x00ff0000) >>  8) |
+         ((x & 0xff000000) >> 24);
+}
+
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER <= 1200
-#define SWAP64(val)                                             \
-	((((uint64_t)(val) & 0x00000000000000ff) << 56)      \
-	 | (((uint64_t)(val) & 0x000000000000ff00) << 40)    \
-	 | (((uint64_t)(val) & 0x0000000000ff0000) << 24)    \
-	 | (((uint64_t)(val) & 0x00000000ff000000) << 8)     \
-	 | (((uint64_t)(val) & 0x000000ff00000000) >> 8)     \
-	 | (((uint64_t)(val) & 0x0000ff0000000000) >> 24)    \
-	 | (((uint64_t)(val) & 0x00ff000000000000) >> 40)    \
-	 | (((uint64_t)(val) & 0xff00000000000000) >> 56))
+static INLINE uint64_t SWAP64(uint64_t val)
+{
+  return
+      ((val & 0x00000000000000ff) << 56)
+    | ((val & 0x000000000000ff00) << 40)
+    | ((val & 0x0000000000ff0000) << 24)
+    | ((val & 0x00000000ff000000) << 8)
+    | ((val & 0x000000ff00000000) >> 8)
+    | ((val & 0x0000ff0000000000) >> 24)
+    | ((val & 0x00ff000000000000) >> 40)
+    | ((val & 0xff00000000000000) >> 56);
+}
 #else
-#define SWAP64(val)                                             \
-	((((uint64_t)(val) & 0x00000000000000ffULL) << 56)      \
-	 | (((uint64_t)(val) & 0x000000000000ff00ULL) << 40)    \
-	 | (((uint64_t)(val) & 0x0000000000ff0000ULL) << 24)    \
-	 | (((uint64_t)(val) & 0x00000000ff000000ULL) << 8)     \
-	 | (((uint64_t)(val) & 0x000000ff00000000ULL) >> 8)     \
-	 | (((uint64_t)(val) & 0x0000ff0000000000ULL) >> 24)    \
-	 | (((uint64_t)(val) & 0x00ff000000000000ULL) >> 40)    \
-	 | (((uint64_t)(val) & 0xff00000000000000ULL) >> 56))
+static INLINE uint64_t SWAP64(uint64_t val)
+{
+  return   ((val & 0x00000000000000ffULL) << 56)
+	 | ((val & 0x000000000000ff00ULL) << 40)
+	 | ((val & 0x0000000000ff0000ULL) << 24)
+	 | ((val & 0x00000000ff000000ULL) << 8)
+	 | ((val & 0x000000ff00000000ULL) >> 8)
+	 | ((val & 0x0000ff0000000000ULL) >> 24)
+	 | ((val & 0x00ff000000000000ULL) >> 40)
+         | ((val & 0xff00000000000000ULL) >> 56);
+}
 #endif
 
 


### PR DESCRIPTION
Those macros reference the parameter multiple times, so
if it has any side effects, like incrementing, then the
code gets screwed. Even worse: number of increments depends on
endianness.

This uses inline functions in the same way as they were already used in
this file.