### PR TITLE
Prevent path_relative_to function from trimming too many characters

### DIFF
--- a/file/file_path.c
+++ b/file/file_path.c
@@ -764,7 +764,7 @@ end:
 size_t path_relative_to(char *out,
       const char *path, const char *base, size_t size)
 {
-   size_t i;
+   size_t i, j;
    const char *trimmed_path, *trimmed_base;
 
 #ifdef _WIN32
@@ -776,9 +776,11 @@ size_t path_relative_to(char *out,
 #endif
 
    /* Trim common beginning */
-   for (i = 0; path[i] && base[i] && path[i] == base[i]; )
-      i++;
-   trimmed_path = path+i;
+   for (i = 0, j = 0; path[i] && base[i] && path[i] == base[i]; i++)
+      if (path[i] == path_default_slash_c())
+         j = i + 1;
+
+   trimmed_path = path+j;
    trimmed_base = base+i;
 
    /* Each segment of base turns into ".." */


### PR DESCRIPTION
On the file path function **path_relative_to**, given two paths that share a common beginning but differ on a directory where both share the first characters, the resulting relative path is wrong because it's trimming too much of the original path. For example:

> * path:  
> **/home/johanbcn/retroarch-old**/shaders/shaders_glsl/crt/shaders/crt-cgwg-fast.glsl
> * base:  
> **/home/johanbcn/retroarch**/shaders/
> * output:  
> **../../-old**/shaders/shaders_glsl/crt/shaders/crt-cgwg-fast.glsl

This pull request fixes this behavior; the following examples were tested:

> * path:  
> **/home/johanbcn/retroarch-old**/shaders/shaders_glsl/crt/shaders/crt-cgwg-fast.glsl
> * base:  
> **/home/johanbcn/retroarch**/shaders/
> * previous output:  
> **../../-old**/shaders/shaders_glsl/crt/shaders/crt-cgwg-fast.glsl
> * corrected output:  
> **../../retroarch-old**/shaders/shaders_glsl/crt/shaders/crt-cgwg-fast.glsl

> * path:  
> **/home/johanbcn/.local/share/libretro/shaders**/shaders_glsl/crt/shaders/crt-cgwg-fast.glsl"
> * base:  
> **/home/johanbcn/.local/share/libretro/shaders**/
> * previous output: 
> shaders_glsl/crt/shaders/crt-cgwg-fast.glsl
> * corrected output:  
> shaders_glsl/crt/shaders/crt-cgwg-fast.glsl

> * path:  
> **/home/johanbcn/.local**/share/libretro/shaders/shaders_glsl/crt/shaders/crt-cgwg-fast.glsl
> * base:  
> **/home/johanbcn/.config**/retroarch/config/"
> * previous output:  
> **../../../local**/share/libretro/shaders/shaders_glsl/crt/shaders/crt-cgwg-fast.glsl
> * corrected output:
> **../../../.local**/share/libretro/shaders/shaders_glsl/crt/shaders/crt-cgwg-fast.glsl

> * path:  
> **/home/johanbcn/retroarch/shaders**/crt-cgwg-fast.glsl
> * base:  
> **/home/johanbcn/retroarch/shaders**/
> * previous output:  
> crt-cgwg-fast.glsl
> * corrected output:  
> crt-cgwg-fast.glsl

> * path:  
> /foo/johanbcn/retroarch/shaders/crt-cgwg-fast.glsl
> * base:  
> /bar/johanbcn/retroarch/shaders/
> * previous output:  
> ../../../../foo/johanbcn/retroarch/shaders/crt-cgwg-fast.glsl
> * corrected output:  
> ../../../../foo/johanbcn/retroarch/shaders/crt-cgwg-fast.glsl
