### PR TITLE
Add 'rzip_stream' and 'm3u_file' libraries

### DIFF
--- a/formats/m3u/m3u_file.c
+++ b/formats/m3u/m3u_file.c
@@ -1,0 +1,635 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (m3u_file.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <retro_miscellaneous.h>
+
+#include <string/stdstring.h>
+#include <lists/string_list.h>
+#include <file/file_path.h>
+#include <streams/file_stream.h>
+
+#include <formats/m3u_file.h>
+
+/* We parse the following types of entry label:
+ * - '#LABEL:<label>' non-standard, but used by
+ *   some cores
+ * - '#EXTINF:<runtime>,<label>' standard extended
+ *   M3U directive
+ * - '<content path>|<label>' non-standard, but
+ *   used by some cores
+ * All other comments/directives are ignored */
+#define M3U_FILE_COMMENT            '#'
+#define M3U_FILE_NONSTD_LABEL       "#LABEL:"
+#define M3U_FILE_EXTSTD_LABEL       "#EXTINF:"
+#define M3U_FILE_EXTSTD_LABEL_TOKEN ','
+#define M3U_FILE_RETRO_LABEL_TOKEN  '|'
+
+/* Holds all internal M3U file data
+ * > Note the awkward name: 'content_m3u_file'
+ *   If we used just 'm3u_file' here, it would
+ *   lead to conflicts elsewhere... */
+struct content_m3u_file
+{
+   char *path;
+   size_t size;
+   size_t capacity;
+   m3u_file_entry_t *entries;
+};
+
+/* File Initialisation / De-Initialisation */
+
+/* Reads M3U file contents from disk
+ * - Does nothing if file does not exist 
+ * - Returns false in the event of an error */
+static bool m3u_file_load(m3u_file_t *m3u_file)
+{
+   const char *file_ext      = NULL;
+   int64_t file_len          = 0;
+   uint8_t *file_buf         = NULL;
+   struct string_list *lines = NULL;
+   size_t i;
+   char entry_path[PATH_MAX_LENGTH];
+   char entry_label[PATH_MAX_LENGTH];
+
+   entry_path[0]  = '\0';
+   entry_label[0] = '\0';
+
+   if (!m3u_file)
+      return false;
+
+   /* Check whether file exists
+    * > If path is empty, then an error
+    *   has occurred... */
+   if (string_is_empty(m3u_file->path))
+      return false;
+
+   /* > File must have the correct extension */
+   file_ext = path_get_extension(m3u_file->path);
+
+   if (string_is_empty(file_ext))
+      return false;
+
+   if (!string_is_equal_noncase(file_ext, M3U_FILE_EXT))
+      return false;
+
+   /* > If file does not exist, no action
+    *   is required */
+   if (!path_is_valid(m3u_file->path))
+      return true;
+
+   /* Read file from disk */
+   if (filestream_read_file(m3u_file->path, (void**)&file_buf, &file_len) >= 0)
+   {
+      /* Split file into lines */
+      if (file_len > 0)
+         lines = string_split((const char*)file_buf, "\n");
+
+      /* File buffer no longer required */
+      if (file_buf)
+         free(file_buf);
+   }
+   else
+   {
+      /* File IO error... */
+      if (file_buf)
+         free(file_buf);
+      return false;
+   }
+
+   /* If file was empty, no action is required */
+   if (!lines)
+      return true;
+
+   /* Parse lines of file */
+   for (i = 0; i < lines->size; i++)
+   {
+      const char *line = lines->elems[i].data;
+
+      if (string_is_empty(line))
+         continue;
+
+      /* Determine line 'type' */
+
+      /* > '#LABEL:' */
+      if (!strncmp(
+            line, M3U_FILE_NONSTD_LABEL,
+            strlen(M3U_FILE_NONSTD_LABEL)))
+      {
+         /* Label is the string to the right
+          * of '#LABEL:' */
+         const char *label = line + strlen(M3U_FILE_NONSTD_LABEL);
+
+         if (!string_is_empty(label))
+         {
+            strlcpy(
+                  entry_label, line + strlen(M3U_FILE_NONSTD_LABEL),
+                  sizeof(entry_label));
+            string_trim_whitespace(entry_label);
+         }
+      }
+      /* > '#EXTINF:' */
+      else if (!strncmp(
+            line, M3U_FILE_EXTSTD_LABEL,
+            strlen(M3U_FILE_EXTSTD_LABEL)))
+      {
+         /* Label is the string to the right
+          * of the first comma */
+         const char* label_ptr = strchr(
+               line + strlen(M3U_FILE_EXTSTD_LABEL),
+               M3U_FILE_EXTSTD_LABEL_TOKEN);
+
+         if (!string_is_empty(label_ptr))
+         {
+            label_ptr++;
+            if (!string_is_empty(label_ptr))
+            {
+               strlcpy(entry_label, label_ptr, sizeof(entry_label));
+               string_trim_whitespace(entry_label);
+            }
+         }
+      }
+      /* > Ignore other comments/directives */
+      else if (line[0] == M3U_FILE_COMMENT)
+         continue;
+      /* > An actual 'content' line */
+      else
+      {
+         /* This is normally a file name/path, but may
+          * have the format <content path>|<label> */
+         const char *token_ptr = strchr(line, M3U_FILE_RETRO_LABEL_TOKEN);
+
+         if (token_ptr)
+         {
+            size_t len = (size_t)(1 + token_ptr - line);
+
+            /* Get entry_path segment */
+            if (len > 0)
+            {
+               memset(entry_path, 0, sizeof(entry_path));
+               strlcpy(
+                     entry_path, line,
+                     ((len < PATH_MAX_LENGTH ?
+                           len : PATH_MAX_LENGTH) * sizeof(char)));
+               string_trim_whitespace(entry_path);
+            }
+
+            /* Get entry_label segment */
+            token_ptr++;
+            if (*token_ptr != '\0')
+            {
+               strlcpy(entry_label, token_ptr, sizeof(entry_label));
+               string_trim_whitespace(entry_label);
+            }
+         }
+         else
+         {
+            /* Just a normal file name/path */
+            strlcpy(entry_path, line, sizeof(entry_path));
+            string_trim_whitespace(entry_path);
+         }
+
+         /* Add entry to file
+          * > Ignore errors here - invalid entries
+          *   will just be omitted */
+         m3u_file_add_entry(m3u_file, entry_path, entry_label);
+
+         /* Reset entry_path/entry_label */
+         entry_path[0]  = '\0';
+         entry_label[0] = '\0';
+      }
+   }
+
+   /* Clean up */
+   if (lines)
+   {
+      string_list_free(lines);
+      lines = NULL;
+   }
+
+   return true;
+}
+
+/* Creates and initialises an M3U file
+ * - If 'path' refers to an existing file,
+ *   contents is parsed
+ * - If path does not exist, an empty M3U file
+ *   is created
+ * - Returned m3u_file_t object must be free'd using
+ *   m3u_file_free()
+ * - Returns NULL in the event of an error */
+m3u_file_t *m3u_file_init(const char *path, size_t size)
+{
+   m3u_file_entry_t *entries = NULL;
+   m3u_file_t *m3u_file      = NULL;
+   char m3u_path[PATH_MAX_LENGTH];
+
+   m3u_path[0] = '\0';
+
+   /* Sanity check */
+   if (string_is_empty(path) || (size < 1))
+      return NULL;
+
+   /* Get 'real' file path */
+   strlcpy(m3u_path, path, sizeof(m3u_path));
+   path_resolve_realpath(m3u_path, sizeof(m3u_path), false);
+
+   if (string_is_empty(m3u_path))
+      return NULL;
+
+   /* Create m3u_file_t object */
+   m3u_file = (m3u_file_t*)calloc(1, sizeof(*m3u_file));
+
+   if (!m3u_file)
+      return NULL;
+
+   /* Create m3u_file_entry_t array */
+   entries = (m3u_file_entry_t*)calloc(size, sizeof(*entries));
+
+   if (!entries)
+   {
+      free(m3u_file);
+      return NULL;
+   }
+
+   /* Copy file path */
+   m3u_file->path = strdup(m3u_path);
+
+   /* Set remaining values */
+   m3u_file->size     = 0;
+   m3u_file->capacity = size;
+   m3u_file->entries  = entries;
+
+   /* Read existing file contents from
+    * disk, if required */
+   if (!m3u_file_load(m3u_file))
+   {
+      m3u_file_free(m3u_file);
+      return NULL;
+   }
+
+   return m3u_file;
+}
+
+/* Frees specified M3U file entry */
+static void m3u_file_free_entry(m3u_file_entry_t *entry)
+{
+   if (!entry)
+      return;
+
+   if (entry->path)
+      free(entry->path);
+
+   if (entry->full_path)
+      free(entry->full_path);
+
+   if (entry->label)
+      free(entry->label);
+
+   entry->path      = NULL;
+   entry->full_path = NULL;
+   entry->label     = NULL;
+}
+
+/* Frees specified M3U file */
+void m3u_file_free(m3u_file_t *m3u_file)
+{
+   size_t i;
+
+   if (!m3u_file)
+      return;
+
+   if (m3u_file->path)
+      free(m3u_file->path);
+
+   m3u_file->path = NULL;
+
+   /* Free entries */
+   if (m3u_file->entries)
+   {
+      for (i = 0; i < m3u_file->size; i++)
+      {
+         m3u_file_entry_t *entry = &m3u_file->entries[i];
+         m3u_file_free_entry(entry);
+      }
+
+      free(m3u_file->entries);
+   }
+   m3u_file->entries = NULL;
+
+   free(m3u_file);
+}
+
+/* Getters */
+
+/* Returns M3U file path */
+char *m3u_file_get_path(m3u_file_t *m3u_file)
+{
+   if (!m3u_file)
+      return NULL;
+
+   return m3u_file->path;
+}
+
+/* Returns number of entries in M3U file */
+size_t m3u_file_get_size(m3u_file_t *m3u_file)
+{
+   if (!m3u_file)
+      return 0;
+
+   return m3u_file->size;
+}
+
+/* Returns maximum number of entries permitted
+ * in M3U file */
+size_t m3u_file_get_capacity(m3u_file_t *m3u_file)
+{
+   if (!m3u_file)
+      return 0;
+
+   return m3u_file->capacity;
+}
+
+/* Fetches specified M3U file entry
+ * - Returns false if 'idx' is invalid, or internal
+ *   entry is NULL */
+bool m3u_file_get_entry(
+      m3u_file_t *m3u_file, size_t idx, m3u_file_entry_t **entry)
+{
+   if (!m3u_file ||
+       !entry ||
+       (idx >= m3u_file->size) ||
+       !m3u_file->entries)
+      return false;
+
+   *entry = &m3u_file->entries[idx];
+
+   if (!*entry)
+      return false;
+
+   return true;
+}
+
+/* Setters */
+
+/* Adds specified entry to the M3U file
+ * - Returns false if path is invalid, or M3U
+ *   file capacity is exceeded */
+bool m3u_file_add_entry(
+      m3u_file_t *m3u_file, const char *path, const char *label)
+{
+   m3u_file_entry_t *entry = NULL;
+   char full_path[PATH_MAX_LENGTH];
+
+   full_path[0] = '\0';
+
+   if (!m3u_file ||
+       !m3u_file->entries ||
+       (m3u_file->size >= m3u_file->capacity) ||
+       string_is_empty(path))
+      return false;
+
+   /* Get new entry at end of list */
+   entry = &m3u_file->entries[m3u_file->size];
+
+   if (!entry)
+      return false;
+
+   /* Ensure entry is free'd */
+   m3u_file_free_entry(entry);
+
+   /* Copy path and label */
+   entry->path = strdup(path);
+
+   if (!string_is_empty(label))
+      entry->label = strdup(label);
+
+   /* Populate 'full_path' field */
+   if (path_is_absolute(path))
+   {
+      strlcpy(full_path, path, sizeof(full_path));
+      path_resolve_realpath(full_path, sizeof(full_path), false);
+   }
+   else
+      fill_pathname_resolve_relative(
+            full_path, m3u_file->path, path,
+            sizeof(full_path));
+
+   /* Handle unforeseen errors... */
+   if (string_is_empty(full_path))
+   {
+      m3u_file_free_entry(entry);
+      return false;
+   }
+
+   entry->full_path = strdup(full_path);
+
+   /* Increment size counter */
+   m3u_file->size++;
+
+   return true;
+}
+
+/* Removes all entries in M3U file */
+void m3u_file_clear(m3u_file_t *m3u_file)
+{
+   size_t i;
+
+   if (!m3u_file)
+      return;
+
+   if (m3u_file->entries)
+   {
+      for (i = 0; i < m3u_file->size; i++)
+      {
+         m3u_file_entry_t *entry = &m3u_file->entries[i];
+         m3u_file_free_entry(entry);
+      }
+   }
+
+   m3u_file->size = 0;
+}
+
+/* Saving */
+
+/* Saves M3U file to disk
+ * - Setting 'label_type' to M3U_FILE_LABEL_NONE
+ *   just outputs entry paths - this the most
+ *   common format supported by most cores
+ * - Returns false in the event of an error */
+bool m3u_file_save(
+      m3u_file_t *m3u_file, enum m3u_file_label_type label_type)
+{
+   RFILE *file = NULL;
+   size_t i;
+   char base_dir[PATH_MAX_LENGTH];
+
+   base_dir[0] = '\0';
+
+   if (!m3u_file || !m3u_file->entries)
+      return false;
+
+   /* This should never happen */
+   if (string_is_empty(m3u_file->path))
+      return false;
+
+   /* Get M3U file base directory */
+   if (find_last_slash(m3u_file->path))
+   {
+      strlcpy(base_dir, m3u_file->path, sizeof(base_dir));
+      path_basedir(base_dir);
+   }
+
+   /* Open file for writing */
+   file = filestream_open(
+         m3u_file->path,
+         RETRO_VFS_FILE_ACCESS_WRITE,
+         RETRO_VFS_FILE_ACCESS_HINT_NONE);
+
+   if (!file)
+      return false;
+
+   /* Loop over entries */
+   for (i = 0; i < m3u_file->size; i++)
+   {
+      m3u_file_entry_t *entry = &m3u_file->entries[i];
+      char entry_path[PATH_MAX_LENGTH];
+
+      entry_path[0] = '\0';
+
+      if (!entry || string_is_empty(entry->full_path))
+         continue;
+
+      /* When writing M3U files, entry paths are
+       * always relative */
+      if (string_is_empty(base_dir))
+         strlcpy(
+               entry_path, entry->full_path,
+               sizeof(entry_path));
+      else
+         path_relative_to(
+               entry_path, entry->full_path, base_dir,
+               sizeof(entry_path));
+
+      if (string_is_empty(entry_path))
+         continue;
+
+      /* Check if we need to write a label */
+      if (!string_is_empty(entry->label))
+      {
+         switch (label_type)
+         {
+            case M3U_FILE_LABEL_NONSTD:
+               filestream_printf(
+                     file, "%s%s\n%s\n",
+                     M3U_FILE_NONSTD_LABEL, entry->label,
+                     entry_path);
+               break;
+            case M3U_FILE_LABEL_EXTSTD:
+               filestream_printf(
+                     file, "%s%c%s\n%s\n",
+                     M3U_FILE_EXTSTD_LABEL, M3U_FILE_EXTSTD_LABEL_TOKEN, entry->label,
+                     entry_path);
+               break;
+            case M3U_FILE_LABEL_RETRO:
+               filestream_printf(
+                     file, "%s%c%s\n",
+                     entry_path, M3U_FILE_RETRO_LABEL_TOKEN, entry->label);
+               break;
+            case M3U_FILE_LABEL_NONE:
+            default:
+               filestream_printf(
+                     file, "%s\n", entry_path);
+               break;
+         }
+      }
+      /* No label - just write entry path */
+      else
+         filestream_printf(
+               file, "%s\n", entry_path);
+   }
+
+   /* Close file */
+   filestream_close(file);
+
+   return true;
+}
+
+/* Utilities */
+
+/* Internal qsort function */
+static int m3u_file_qsort_func(
+      const m3u_file_entry_t *a, const m3u_file_entry_t *b)
+{
+   if (!a || !b)
+      return 0;
+
+   if (string_is_empty(a->full_path) || string_is_empty(b->full_path))
+      return 0;
+
+   return strcasecmp(a->full_path, b->full_path);
+}
+
+/* Sorts M3U file entries in alphabetical order */
+void m3u_file_qsort(m3u_file_t *m3u_file)
+{
+   if (!m3u_file ||
+       !m3u_file->entries ||
+       (m3u_file->size < 2))
+      return;
+
+   qsort(
+         m3u_file->entries, m3u_file->size,
+         sizeof(m3u_file_entry_t),
+         (int (*)(const void *, const void *))m3u_file_qsort_func);
+}
+
+/* Returns true if specified path corresponds
+ * to an M3U file (simple convenience function) */
+bool m3u_file_is_m3u(const char *path)
+{
+   const char *file_ext = NULL;
+   int32_t file_size;
+
+   if (string_is_empty(path))
+      return false;
+
+   /* Check file extension */
+   file_ext = path_get_extension(path);
+
+   if (string_is_empty(file_ext))
+      return false;
+
+   if (!string_is_equal_noncase(file_ext, M3U_FILE_EXT))
+      return false;
+
+   /* Ensure file exists */
+   if (!path_is_valid(path))
+      return false;
+
+   /* Ensure we have non-zero file size */
+   file_size = path_get_size(path);
+
+   if (file_size <= 0)
+      return false;
+
+   return true;
+}

--- a/include/formats/m3u_file.h
+++ b/include/formats/m3u_file.h
@@ -1,0 +1,128 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (m3u_file.h).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __LIBRETRO_SDK_FORMAT_M3U_FILE_H__
+#define __LIBRETRO_SDK_FORMAT_M3U_FILE_H__
+
+#include <retro_common_api.h>
+
+#include <stdint.h>
+#include <stddef.h>
+#include <boolean.h>
+
+RETRO_BEGIN_DECLS
+
+/* Trivial handler for M3U playlist files */
+
+/* M3U file extension */
+#define M3U_FILE_EXT "m3u"
+
+/* Default maximum number of M3U entries */
+#define M3U_FILE_SIZE 2048
+
+/* Prevent direct access to m3u_file_t members */
+typedef struct content_m3u_file m3u_file_t;
+
+/* Holds all metadata for a single M3U file entry */
+typedef struct
+{
+   char *path;
+   char *full_path;
+   char *label;
+} m3u_file_entry_t;
+
+/* Defines entry label formatting when
+ * writing M3U files to disk */
+enum m3u_file_label_type
+{
+   M3U_FILE_LABEL_NONE = 0,
+   M3U_FILE_LABEL_NONSTD,
+   M3U_FILE_LABEL_EXTSTD,
+   M3U_FILE_LABEL_RETRO
+};
+
+/* File Initialisation / De-Initialisation */
+
+/* Creates and initialises an M3U file
+ * - If 'path' refers to an existing file,
+ *   contents is parsed
+ * - If path does not exist, an empty M3U file
+ *   is created
+ * - Returned m3u_file_t object must be free'd using
+ *   m3u_file_free()
+ * - Returns NULL in the event of an error */
+m3u_file_t *m3u_file_init(const char *path, size_t size);
+
+/* Frees specified M3U file */
+void m3u_file_free(m3u_file_t *m3u_file);
+
+/* Getters */
+
+/* Returns M3U file path */
+char *m3u_file_get_path(m3u_file_t *m3u_file);
+
+/* Returns number of entries in M3U file */
+size_t m3u_file_get_size(m3u_file_t *m3u_file);
+
+/* Returns maximum number of entries permitted
+ * in M3U file */
+size_t m3u_file_get_capacity(m3u_file_t *m3u_file);
+
+/* Fetches specified M3U file entry
+ * - Returns false if 'idx' is invalid, or internal
+ *   entry is NULL */
+bool m3u_file_get_entry(
+      m3u_file_t *m3u_file, size_t idx, m3u_file_entry_t **entry);
+
+/* Setters */
+
+/* Adds specified entry to the M3U file
+ * - Returns false if path is invalid, or M3U
+ *   file capacity is exceeded */
+bool m3u_file_add_entry(
+      m3u_file_t *m3u_file, const char *path, const char *label);
+
+/* Removes all entries in M3U file */
+void m3u_file_clear(m3u_file_t *m3u_file);
+
+/* Saving */
+
+/* Saves M3U file to disk
+ * - Setting 'label_type' to M3U_FILE_LABEL_NONE
+ *   just outputs entry paths - this the most
+ *   common format supported by most cores
+ * - Returns false in the event of an error */
+bool m3u_file_save(
+      m3u_file_t *m3u_file, enum m3u_file_label_type label_type);
+
+/* Utilities */
+
+/* Sorts M3U file entries in alphabetical order */
+void m3u_file_qsort(m3u_file_t *m3u_file);
+
+/* Returns true if specified path corresponds
+ * to an M3U file (simple convenience function) */
+bool m3u_file_is_m3u(const char *path);
+
+RETRO_END_DECLS
+
+#endif

--- a/include/streams/rzip_stream.h
+++ b/include/streams/rzip_stream.h
@@ -1,0 +1,188 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (rzip_stream.h).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef _LIBRETRO_SDK_FILE_RZIP_STREAM_H
+#define _LIBRETRO_SDK_FILE_RZIP_STREAM_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdarg.h>
+
+#include <retro_common_api.h>
+
+RETRO_BEGIN_DECLS
+
+/* Rudimentary interface for streaming data to/from a
+ * zlib-compressed chunk-based RZIP archive file.
+ * 
+ * This is somewhat less efficient than using regular
+ * gzip code, but this is by design - the intention here
+ * is to create an interface that integrates seamlessly
+ * with normal RetroArch functionality, using only
+ * standard/existing libretro-common routines.
+ * (Actual efficiency is pretty good, regardless:
+ * archived file size is almost identical to a solid
+ * zip file, and compression/decompression speed is
+ * not substantially worse than external archiving tools;
+ * it is certainly acceptable for use in real-time
+ * frontend applications)
+ * 
+ * When reading existing files, uncompressed content
+ * is handled automatically. File type (compressed/
+ * uncompressed) is detected via the RZIP header.
+ * 
+ * ## RZIP file format:
+ * 
+ * <file id header>:                8 bytes
+ *                                  - [#][R][Z][I][P][v][file format version][#]
+ * <uncompressed chunk size>:       4 bytes, little endian order
+ *                                  - nominal (maximum) size of each uncompressed
+ *                                    chunk, in bytes
+ * <total uncompressed data size>:  8 bytes, little endian order
+ * <size of next compressed chunk>: 4 bytes, little endian order
+ *                                  - size on-disk of next compressed data
+ *                                    chunk, in bytes
+ * <next compressed chunk>:         n bytes of zlib compressed data
+ * ...
+ * <size of next compressed chunk> : repeated until end of file
+ * <next compressed chunk>         :
+ * 
+ */
+
+/* Prevent direct access to rzipstream_t members */
+typedef struct rzipstream rzipstream_t;
+
+/* File Open */
+
+/* Opens a new or existing RZIP file
+ * > Supported 'mode' values are:
+ *   - RETRO_VFS_FILE_ACCESS_READ
+ *   - RETRO_VFS_FILE_ACCESS_WRITE
+ * > When reading, 'path' may reference compressed
+ *   or uncompressed data
+ * Returns NULL if arguments are invalid, file
+ * is invalid or an IO error occurs */
+rzipstream_t* rzipstream_open(const char *path, unsigned mode);
+
+/* File Read */
+
+/* Reads (a maximum of) 'len' bytes from an RZIP file.
+ * Returns actual number of bytes read, or -1 in
+ * the event of an error */
+int64_t rzipstream_read(rzipstream_t *stream, void *data, int64_t len);
+
+/* Reads next character from an RZIP file.
+ * Returns character value, or EOF if no data
+ * remains.
+ * Note: Always returns EOF if file is open
+ * for writing. */
+int rzipstream_getc(rzipstream_t *stream);
+
+/* Reads one line from an RZIP file and stores it
+ * in the character array pointed to by 's'.
+ * It stops reading when either (len-1) characters
+ * are read, the newline character is read, or the
+ * end-of-file is reached, whichever comes first.
+ * On success, returns 's'. In the event of an error,
+ * or if end-of-file is reached and no characters
+ * have been read, returns NULL. */
+char* rzipstream_gets(rzipstream_t *stream, char *s, size_t len);
+
+/* Reads all data from file specified by 'path' and
+ * copies it to 'buf'.
+ * - 'buf' will be allocated and must be free()'d manually.
+ * - Allocated 'buf' size is equal to 'len'.
+ * Returns false in the event of an error */
+bool rzipstream_read_file(const char *path, void **buf, int64_t *len);
+
+/* File Write */
+
+/* Writes 'len' bytes to an RZIP file.
+ * Returns actual number of bytes written, or -1
+ * in the event of an error */
+int64_t rzipstream_write(rzipstream_t *stream, const void *data, int64_t len);
+
+/* Writes a single character to an RZIP file.
+ * Returns character written, or EOF in the event
+ * of an error */
+int rzipstream_putc(rzipstream_t *stream, int c);
+
+/* Writes a variable argument list to an RZIP file.
+ * Ugly 'internal' function, required to enable
+ * 'printf' support in the higher level 'interface_stream'.
+ * Returns actual number of bytes written, or -1
+ * in the event of an error */
+int rzipstream_vprintf(rzipstream_t *stream, const char* format, va_list args);
+
+/* Writes formatted output to an RZIP file.
+ * Returns actual number of bytes written, or -1
+ * in the event of an error */
+int rzipstream_printf(rzipstream_t *stream, const char* format, ...);
+
+/* Writes contents of 'data' buffer to file
+ * specified by 'path'.
+ * Returns false in the event of an error */
+bool rzipstream_write_file(const char *path, const void *data, int64_t len);
+
+/* File Control */
+
+/* Sets file position to the beginning of the
+ * specified RZIP file.
+ * Note: It is not recommended to rewind a file
+ * that is open for writing, since the caller
+ * may end up with a file containing junk data
+ * at the end (harmless, but a waste of space). */
+void rzipstream_rewind(rzipstream_t *stream);
+
+/* File Status */
+
+/* Returns total size (in bytes) of the *uncompressed*
+ * data in an RZIP file.
+ * (If reading an uncompressed file, this corresponds
+ * to the 'physical' file size in bytes)
+ * Returns -1 in the event of a error. */
+int64_t rzipstream_get_size(rzipstream_t *stream);
+
+/* Returns EOF when no further *uncompressed* data
+ * can be read from an RZIP file. */
+int rzipstream_eof(rzipstream_t *stream);
+
+/* Returns the offset of the current byte of *uncompressed*
+ * data relative to the beginning of an RZIP file.
+ * Returns -1 in the event of a error. */
+int64_t rzipstream_tell(rzipstream_t *stream);
+
+/* Returns true if specified RZIP file contains
+ * compressed content */
+bool rzipstream_is_compressed(rzipstream_t *stream);
+
+/* File Close */
+
+/* Closes RZIP file. If file is open for writing,
+ * flushes any remaining buffered data to disk.
+ * Returns -1 in the event of a error. */
+int rzipstream_close(rzipstream_t *stream);
+
+RETRO_END_DECLS
+
+#endif

--- a/streams/rzip_stream.c
+++ b/streams/rzip_stream.c
@@ -1,0 +1,1096 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (rzip_stream.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <string/stdstring.h>
+#include <file/file_path.h>
+
+#include <streams/file_stream.h>
+#include <streams/trans_stream.h>
+
+#include <streams/rzip_stream.h>
+
+/* Current RZIP file format version */
+#define RZIP_VERSION 1
+
+/* Compression level
+ * > zlib default of 6 provides the best
+ *   balance between file size and
+ *   compression speed */
+#define RZIP_COMPRESSION_LEVEL 6
+
+/* Default chunk size: 128kb */
+#define RZIP_DEFAULT_CHUNK_SIZE 131072
+
+/* Header sizes (in bytes) */
+#define RZIP_HEADER_SIZE 20
+#define RZIP_CHUNK_HEADER_SIZE 4
+
+/* Holds all metadata for an RZIP file stream */
+struct rzipstream
+{
+   bool is_compressed;
+   bool is_writing;
+   uint64_t size;
+   uint32_t chunk_size;
+   /* virtual_ptr: Used to track how much
+    * uncompressed data has been read */
+   uint64_t virtual_ptr;
+   RFILE* file;
+   const struct trans_stream_backend *deflate_backend;
+   void *deflate_stream;
+   const struct trans_stream_backend *inflate_backend;
+   void *inflate_stream;
+   uint8_t *in_buf;
+   uint32_t in_buf_size;
+   uint32_t in_buf_ptr;
+   uint8_t *out_buf;
+   uint32_t out_buf_size;
+   uint32_t out_buf_ptr;
+   uint32_t out_buf_occupancy;
+};
+
+/* Header Functions */
+
+/* Reads header information from RZIP file
+ * > Detects whether file is compressed or
+ *   uncompressed data
+ * > If compressed, extracts uncompressed
+ *   file/chunk sizes */
+static bool rzipstream_read_file_header(rzipstream_t *stream)
+{
+   uint8_t header_bytes[RZIP_HEADER_SIZE] = {0};
+   int64_t length;
+
+   if (!stream)
+      return false;
+
+   /* Attempt to read header bytes */
+   length = filestream_read(stream->file, header_bytes, sizeof(header_bytes));
+   if (length <= 0)
+      return false;
+
+   /* If file length is less than header size
+    * then assume this is uncompressed data */
+   if (length < RZIP_HEADER_SIZE)
+      goto file_uncompressed;
+
+   /* Check 'magic numbers' - first 8 bytes
+    * of header */
+   if ((header_bytes[0] !=           35) || /* # */
+       (header_bytes[1] !=           82) || /* R */
+       (header_bytes[2] !=           90) || /* Z */
+       (header_bytes[3] !=           73) || /* I */
+       (header_bytes[4] !=           80) || /* P */
+       (header_bytes[5] !=          118) || /* v */
+       (header_bytes[6] != RZIP_VERSION) || /* file format version number */
+       (header_bytes[7] !=           35))   /* # */
+      goto file_uncompressed;
+
+   /* Get uncompressed chunk size - next 4 bytes */
+   stream->chunk_size = ((uint32_t)header_bytes[11] << 24) |
+                        ((uint32_t)header_bytes[10] << 16) |
+                        ((uint32_t)header_bytes[9]  <<  8) |
+                         (uint32_t)header_bytes[8];
+   if (stream->chunk_size == 0)
+      return false;
+
+   /* Get total uncompressed data size - next 8 bytes */
+   stream->size = ((uint64_t)header_bytes[19] << 56) |
+                  ((uint64_t)header_bytes[18] << 48) |
+                  ((uint64_t)header_bytes[17] << 40) |
+                  ((uint64_t)header_bytes[16] << 32) |
+                  ((uint64_t)header_bytes[15] << 24) |
+                  ((uint64_t)header_bytes[14] << 16) |
+                  ((uint64_t)header_bytes[13] <<  8) |
+                   (uint64_t)header_bytes[12];
+   if (stream->size == 0)
+      return false;
+
+   stream->is_compressed = true;
+   return true;
+
+file_uncompressed:
+
+   /* Reset file to start */
+   filestream_seek(stream->file, 0, SEEK_SET);
+
+   /* Get 'raw' file size */
+   stream->size = filestream_get_size(stream->file);
+
+   stream->is_compressed = false;
+   return true;
+}
+
+/* Writes header information to RZIP file
+ * > ID 'magic numbers' + uncompressed
+ *   file/chunk sizes */
+static bool rzipstream_write_file_header(rzipstream_t *stream)
+{
+   uint8_t header_bytes[RZIP_HEADER_SIZE] = {0};
+   int64_t length;
+
+   if (!stream)
+      return false;
+
+   /* Populate header array */
+
+   /* > 'Magic numbers' - first 8 bytes */
+   header_bytes[0] =           35; /* # */
+   header_bytes[1] =           82; /* R */
+   header_bytes[2] =           90; /* Z */
+   header_bytes[3] =           73; /* I */
+   header_bytes[4] =           80; /* P */
+   header_bytes[5] =          118; /* v */
+   header_bytes[6] = RZIP_VERSION; /* file format version number */
+   header_bytes[7] =           35; /* # */
+
+   /* > Uncompressed chunk size - next 4 bytes */
+   header_bytes[11] = (stream->chunk_size >> 24) & 0xFF;
+   header_bytes[10] = (stream->chunk_size >> 16) & 0xFF;
+   header_bytes[9]  = (stream->chunk_size >>  8) & 0xFF;
+   header_bytes[8]  =  stream->chunk_size        & 0xFF;
+
+   /* > Total uncompressed data size - next 8 bytes */
+   header_bytes[19] = (stream->size >> 56) & 0xFF;
+   header_bytes[18] = (stream->size >> 48) & 0xFF;
+   header_bytes[17] = (stream->size >> 40) & 0xFF;
+   header_bytes[16] = (stream->size >> 32) & 0xFF;
+   header_bytes[15] = (stream->size >> 24) & 0xFF;
+   header_bytes[14] = (stream->size >> 16) & 0xFF;
+   header_bytes[13] = (stream->size >>  8) & 0xFF;
+   header_bytes[12] =  stream->size        & 0xFF;
+
+   /* Reset file to start */
+   filestream_seek(stream->file, 0, SEEK_SET);
+
+   /* Write header bytes */
+   length = filestream_write(stream->file, header_bytes, sizeof(header_bytes));
+   if (length != RZIP_HEADER_SIZE)
+      return false;
+
+   return true;
+}
+
+/* Stream Initialisation/De-initialisation */
+
+/* Initialises all members of an rzipstream_t struct,
+ * reading config from existing file header if available */
+static bool rzipstream_init_stream(
+      rzipstream_t *stream, const char *path, bool is_writing)
+{
+   unsigned file_mode;
+
+   if (!stream)
+      return false;
+
+   /* Ensure stream has valid initial values */
+   stream->size              = 0;
+   stream->chunk_size        = RZIP_DEFAULT_CHUNK_SIZE;
+   stream->file              = NULL;
+   stream->deflate_backend   = NULL;
+   stream->deflate_stream    = NULL;
+   stream->inflate_backend   = NULL;
+   stream->inflate_stream    = NULL;
+   stream->in_buf            = NULL;
+   stream->in_buf_size       = 0;
+   stream->in_buf_ptr        = 0;
+   stream->out_buf           = NULL;
+   stream->out_buf_size      = 0;
+   stream->out_buf_ptr       = 0;
+   stream->out_buf_occupancy = 0;
+
+   /* Check whether this is a read or write stream */
+   stream->is_writing = is_writing;
+   if (stream->is_writing)
+   {
+      /* Written files are always compressed */
+      stream->is_compressed = true;
+      file_mode             = RETRO_VFS_FILE_ACCESS_WRITE;
+   }
+   /* For read files, must get compression status
+    * from file itself... */
+   else
+      file_mode             = RETRO_VFS_FILE_ACCESS_READ;
+
+   /* Open file */
+   stream->file = filestream_open(
+         path, file_mode, RETRO_VFS_FILE_ACCESS_HINT_NONE);
+   if (!stream->file)
+      return false;
+
+   /* If file is open for writing, output header
+    * (Size component cannot be written until
+    * file is closed...) */
+   if (stream->is_writing)
+   {
+      /* Note: could just write zeros here, but
+       * still want to identify this as an RZIP
+       * file if writing fails partway through */
+      if (!rzipstream_write_file_header(stream))
+         return false;
+   }
+   /* If file is open for reading, parse any existing
+    * header */
+   else if (!rzipstream_read_file_header(stream))
+      return false;
+
+   /* Initialise appropriate transform stream
+    * and determine associated buffer sizes */
+   if (stream->is_writing)
+   {
+      /* Compression */
+      stream->deflate_backend = trans_stream_get_zlib_deflate_backend();
+      if (!stream->deflate_backend)
+         return false;
+
+      stream->deflate_stream = stream->deflate_backend->stream_new();
+      if (!stream->deflate_stream)
+         return false;
+
+      /* Set compression level */
+      if (!stream->deflate_backend->define(
+            stream->deflate_stream, "level", RZIP_COMPRESSION_LEVEL))
+         return false;
+
+      /* Buffers
+       * > Input: uncompressed
+       * > Output: compressed */
+      stream->in_buf_size  = stream->chunk_size;
+      stream->out_buf_size = stream->chunk_size * 2;
+      /* > Account for minimum zlib overhead
+       *   of 11 bytes... */ 
+      stream->out_buf_size =
+            (stream->out_buf_size < (stream->in_buf_size + 11)) ?
+                  stream->out_buf_size + 11 :
+                  stream->out_buf_size;
+
+      /* Redundant safety check */
+      if ((stream->in_buf_size == 0) ||
+          (stream->out_buf_size == 0))
+         return false;
+   }
+   /* When reading, don't need an inflate transform
+    * stream (or buffers) if source file is uncompressed */
+   else if (stream->is_compressed)
+   {
+      /* Decompression */
+      stream->inflate_backend = trans_stream_get_zlib_inflate_backend();
+      if (!stream->inflate_backend)
+         return false;
+
+      stream->inflate_stream = stream->inflate_backend->stream_new();
+      if (!stream->inflate_stream)
+         return false;
+
+      /* Buffers
+       * > Input: compressed
+       * > Output: uncompressed
+       * Note 1: Actual compressed chunk sizes are read
+       *         from the file - just allocate a sensible
+       *         default to minimise memory reallocations
+       * Note 2: If file header is valid, output buffer
+       *         should have a size of exactly stream->chunk_size.
+       *         Allocate some additional space, just for
+       *         redundant safety... */
+      stream->in_buf_size  = stream->chunk_size * 2;
+      stream->out_buf_size = stream->chunk_size + (stream->chunk_size >> 2);
+
+      /* Redundant safety check */
+      if ((stream->in_buf_size == 0) ||
+          (stream->out_buf_size == 0))
+         return false;
+   }
+
+   /* Allocate buffers */
+   if (stream->in_buf_size > 0)
+   {
+      stream->in_buf = (uint8_t *)calloc(stream->in_buf_size, 1);
+      if (!stream->in_buf)
+         return false;
+   }
+
+   if (stream->out_buf_size > 0)
+   {
+      stream->out_buf = (uint8_t *)calloc(stream->out_buf_size, 1);
+      if (!stream->out_buf)
+         return false;
+   }
+
+   return true;
+}
+
+/* free()'s all members of an rzipstream_t struct
+ * > Also closes associated file, if currently open */
+static int rzipstream_free_stream(rzipstream_t *stream)
+{
+   int ret = 0;
+
+   if (!stream)
+      return -1;
+
+   /* Free transform streams */
+   if (stream->deflate_stream && stream->deflate_backend)
+      stream->deflate_backend->stream_free(stream->deflate_stream);
+
+   stream->deflate_stream  = NULL;
+   stream->deflate_backend = NULL;
+
+   if (stream->inflate_stream && stream->inflate_backend)
+      stream->inflate_backend->stream_free(stream->inflate_stream);
+
+   stream->inflate_stream  = NULL;
+   stream->inflate_backend = NULL;
+
+   /* Free buffers */
+   if (stream->in_buf)
+      free(stream->in_buf);
+   stream->in_buf = NULL;
+
+   if (stream->out_buf)
+      free(stream->out_buf);
+   stream->out_buf = NULL;
+
+   /* Close file */
+   if (stream->file)
+      ret = filestream_close(stream->file);
+   stream->file = NULL;
+
+   free(stream);
+
+   return ret;
+}
+
+/* File Open */
+
+/* Opens a new or existing RZIP file
+ * > Supported 'mode' values are:
+ *   - RETRO_VFS_FILE_ACCESS_READ
+ *   - RETRO_VFS_FILE_ACCESS_WRITE
+ * > When reading, 'path' may reference compressed
+ *   or uncompressed data
+ * Returns NULL if arguments are invalid, file
+ * is invalid or an IO error occurs */
+rzipstream_t* rzipstream_open(const char *path, unsigned mode)
+{
+   rzipstream_t *stream = NULL;
+
+   /* Sanity check
+    * > Only RETRO_VFS_FILE_ACCESS_READ and
+    *   RETRO_VFS_FILE_ACCESS_WRITE are supported */
+   if (string_is_empty(path) ||
+       ((mode != RETRO_VFS_FILE_ACCESS_READ) &&
+        (mode != RETRO_VFS_FILE_ACCESS_WRITE)))
+      return NULL;
+
+   /* If opening in read mode, ensure file exists */
+   if ((mode == RETRO_VFS_FILE_ACCESS_READ) &&
+       !path_is_valid(path))
+      return NULL;
+
+   /* Allocate stream object */
+   stream = (rzipstream_t*)calloc(1, sizeof(*stream));
+   if (!stream)
+      return NULL;
+
+   /* Initialise stream */
+   if (!rzipstream_init_stream(
+         stream, path,
+         (mode == RETRO_VFS_FILE_ACCESS_WRITE)))
+   {
+      rzipstream_free_stream(stream);
+      return NULL;
+   }
+
+   return stream;
+}
+
+/* File Read */
+
+/* Reads and decompresses the next chunk of data
+ * in the RZIP file */
+static bool rzipstream_read_chunk(rzipstream_t *stream)
+{
+   uint8_t chunk_header_bytes[RZIP_CHUNK_HEADER_SIZE] = {0};
+   uint32_t compressed_chunk_size;
+   uint32_t inflate_read;
+   uint32_t inflate_written;
+   int64_t length;
+
+   if (!stream || !stream->inflate_backend || !stream->inflate_stream)
+      return false;
+
+   /* Attempt to read chunk header bytes */
+   length = filestream_read(
+         stream->file, chunk_header_bytes, sizeof(chunk_header_bytes));
+   if (length != RZIP_CHUNK_HEADER_SIZE)
+      return false;
+
+   /* Get size of next compressed chunk */
+   compressed_chunk_size = ((uint32_t)chunk_header_bytes[3] << 24) |
+                           ((uint32_t)chunk_header_bytes[2] << 16) |
+                           ((uint32_t)chunk_header_bytes[1] <<  8) |
+                            (uint32_t)chunk_header_bytes[0];
+   if (compressed_chunk_size == 0)
+      return false;
+
+   /* Resize input buffer, if required */
+   if (compressed_chunk_size > stream->in_buf_size)
+   {
+      free(stream->in_buf);
+      stream->in_buf      = NULL;
+
+      stream->in_buf_size = compressed_chunk_size;
+      stream->in_buf      = (uint8_t *)calloc(stream->in_buf_size, 1);
+      if (!stream->in_buf)
+         return false;
+
+      /* Note: Uncompressed data size is fixed, and read
+       * from the file header - we therefore don't attempt
+       * to resize the output buffer (if it's too small, then
+       * that's an error condition) */
+   }
+
+   /* Read compressed chunk from file */
+   length = filestream_read(
+         stream->file, stream->in_buf, compressed_chunk_size);
+   if (length != compressed_chunk_size)
+      return false;
+
+   /* Decompress chunk data */
+   stream->inflate_backend->set_in(
+         stream->inflate_stream,
+         stream->in_buf, compressed_chunk_size);
+
+   stream->inflate_backend->set_out(
+         stream->inflate_stream,
+         stream->out_buf, stream->out_buf_size);
+
+   /* Note: We have to set 'flush == true' here, otherwise we
+    * can't guarantee that the entire chunk will be written
+    * to the output buffer - this is inefficient, but not
+    * much we can do... */
+   if (!stream->inflate_backend->trans(
+         stream->inflate_stream, true,
+         &inflate_read, &inflate_written, NULL))
+      return false;
+
+   /* Error checking */
+   if (inflate_read != compressed_chunk_size)
+      return false;
+
+   if ((inflate_written == 0) ||
+       (inflate_written > stream->out_buf_size))
+      return false;
+
+   /* Record current output buffer occupancy
+    * and reset pointer */
+   stream->out_buf_occupancy = inflate_written;
+   stream->out_buf_ptr       = 0;
+
+   return true;
+}
+
+/* Reads (a maximum of) 'len' bytes from an RZIP file.
+ * Returns actual number of bytes read, or -1 in
+ * the event of an error */
+int64_t rzipstream_read(rzipstream_t *stream, void *data, int64_t len)
+{
+   int64_t data_len  = len;
+   uint8_t *data_ptr = (uint8_t *)data;
+   int64_t data_read = 0;
+
+   if (!stream || stream->is_writing || !data)
+      return -1;
+
+   /* If we are reading uncompressed data, simply
+    * 'pass on' the direct file access request */
+   if (!stream->is_compressed)
+      return filestream_read(stream->file, data, len);
+
+   /* Process input data */
+   while (data_len > 0)
+   {
+      uint32_t read_size = 0;
+
+      /* Check whether we have reached the end
+       * of the file */
+      if (stream->virtual_ptr >= stream->size)
+         return data_read;
+
+      /* If everything in the output buffer has already
+       * been read, grab and extract the next chunk
+       * from disk */
+      if (stream->out_buf_ptr >= stream->out_buf_occupancy)
+         if (!rzipstream_read_chunk(stream))
+            return -1;
+
+      /* Get amount of data to 'read out' this loop
+       * > i.e. minimum of remaining output buffer
+       *   occupancy and remaining 'read data' size */
+      read_size = stream->out_buf_occupancy - stream->out_buf_ptr;
+      read_size = (read_size > data_len) ? data_len : read_size;
+
+      /* Copy as much cached data as possible into
+       * the read buffer */
+      memcpy(data_ptr, stream->out_buf + stream->out_buf_ptr, read_size);
+
+      /* Increment pointers and remaining length */
+      stream->out_buf_ptr += read_size;
+      data_ptr            += read_size;
+      data_len            -= read_size;
+
+      stream->virtual_ptr += read_size;
+
+      data_read           += read_size;
+   }
+
+   return data_read;
+}
+
+/* Reads next character from an RZIP file.
+ * Returns character value, or EOF if no data
+ * remains.
+ * Note: Always returns EOF if file is open
+ * for writing. */
+int rzipstream_getc(rzipstream_t *stream)
+{
+   char c = 0;
+
+   if (!stream || stream->is_writing)
+      return EOF;
+
+   /* Attempt to read a single character */
+   if (rzipstream_read(stream, &c, 1) == 1)
+      return (int)(unsigned char)c;
+
+   return EOF;
+}
+
+/* Reads one line from an RZIP file and stores it
+ * in the character array pointed to by 's'.
+ * It stops reading when either (len-1) characters
+ * are read, the newline character is read, or the
+ * end-of-file is reached, whichever comes first.
+ * On success, returns 's'. In the event of an error,
+ * or if end-of-file is reached and no characters
+ * have been read, returns NULL. */
+char* rzipstream_gets(rzipstream_t *stream, char *s, size_t len)
+{
+   int c         = 0;
+   char *str_ptr = s;
+   size_t str_len;
+
+   if (!stream || stream->is_writing || (len == 0))
+      return NULL;
+
+   /* Read bytes until newline or EOF is reached,
+    * or string buffer is full */
+   for (str_len = (len - 1); str_len > 0; str_len--)
+   {
+      /* Get next character */
+      c = rzipstream_getc(stream);
+
+      /* Check for newline and EOF */
+      if ((c == '\n') || (c == EOF))
+         break;
+
+      /* Copy character to string buffer */
+      *str_ptr++ = c;
+   }
+
+   /* Add NUL termination */
+   *str_ptr = '\0';
+
+   /* Check whether EOF has been reached without
+    * reading any characters */
+   if ((str_ptr == s) && (c == EOF))
+      return NULL;
+
+   return (s);
+}
+
+/* Reads all data from file specified by 'path' and
+ * copies it to 'buf'.
+ * - 'buf' will be allocated and must be free()'d manually.
+ * - Allocated 'buf' size is equal to 'len'.
+ * Returns false in the event of an error */
+bool rzipstream_read_file(const char *path, void **buf, int64_t *len)
+{
+   int64_t bytes_read       = 0;
+   void *content_buf        = NULL;
+   int64_t content_buf_size = 0;
+   rzipstream_t *stream     = NULL;
+
+   if (!buf)
+      return false;
+
+   /* Attempt to open file */
+   stream = rzipstream_open(path, RETRO_VFS_FILE_ACCESS_READ);
+
+   if (!stream)
+   {
+      fprintf(stderr, "[rzipstream] Failed to open file: %s\n", path ? path : "");
+      goto error;
+   }
+
+   /* Get file size */
+   content_buf_size = rzipstream_get_size(stream);
+
+   if (content_buf_size < 0)
+      goto error;
+
+   if ((int64_t)(uint64_t)(content_buf_size + 1) != (content_buf_size + 1))
+      goto error;
+
+   /* Allocate buffer */
+   content_buf = malloc((size_t)(content_buf_size + 1));
+
+   if (!content_buf)
+      goto error;
+
+   /* Read file contents */
+   bytes_read = rzipstream_read(stream, content_buf, content_buf_size);
+
+   if (bytes_read < 0)
+   {
+      fprintf(stderr, "[rzipstream] Failed to read file: %s\n", path);
+      goto error;
+   }
+
+   /* Close file */
+   rzipstream_close(stream);
+   stream = NULL;
+
+   /* Add NUL termination for easy/safe handling of strings.
+    * Will only work with sane character formatting (Unix). */
+   ((char*)content_buf)[bytes_read] = '\0';
+
+   /* Assign buffer */
+   *buf = content_buf;
+
+   /* Assign length value, if required */
+   if (len)
+      *len = bytes_read;
+
+   return true;
+
+error:
+
+   if (stream)
+      rzipstream_close(stream);
+   stream = NULL;
+
+   if (content_buf)
+      free(content_buf);
+   content_buf = NULL;
+
+   if (len)
+      *len = -1;
+
+   *buf = NULL;
+
+   return false;
+}
+
+/* File Write */
+
+/* Compresses currently cached data and writes it
+ * as the next RZIP file chunk */
+static bool rzipstream_write_chunk(rzipstream_t *stream)
+{
+   uint8_t chunk_header_bytes[RZIP_CHUNK_HEADER_SIZE] = {0};
+   uint32_t deflate_read;
+   uint32_t deflate_written;
+   int64_t length;
+
+   if (!stream || !stream->deflate_backend || !stream->deflate_stream)
+      return false;
+
+   /* Compress data currently held in input buffer */
+   stream->deflate_backend->set_in(
+         stream->deflate_stream,
+         stream->in_buf, stream->in_buf_ptr);
+
+   stream->deflate_backend->set_out(
+         stream->deflate_stream,
+         stream->out_buf, stream->out_buf_size);
+
+   /* Note: We have to set 'flush == true' here, otherwise we
+    * can't guarantee that the entire chunk will be written
+    * to the output buffer - this is inefficient, but not
+    * much we can do... */
+   if (!stream->deflate_backend->trans(
+         stream->deflate_stream, true,
+         &deflate_read, &deflate_written, NULL))
+      return false;
+
+   /* Error checking */
+   if (deflate_read != stream->in_buf_ptr)
+      return false;
+
+   if ((deflate_written == 0) ||
+       (deflate_written > stream->out_buf_size))
+      return false;
+
+   /* Write compressed chunk size to file */
+   chunk_header_bytes[3] = (deflate_written >> 24) & 0xFF;
+   chunk_header_bytes[2] = (deflate_written >> 16) & 0xFF;
+   chunk_header_bytes[1] = (deflate_written >>  8) & 0xFF;
+   chunk_header_bytes[0] =  deflate_written        & 0xFF;
+
+   length = filestream_write(
+         stream->file, chunk_header_bytes, sizeof(chunk_header_bytes));
+   if (length != RZIP_CHUNK_HEADER_SIZE)
+      return false;
+
+   /* Write compressed data to file */
+   length = filestream_write(
+         stream->file, stream->out_buf, deflate_written);
+
+   if (length != deflate_written)
+      return false;
+
+   /* Reset input buffer pointer */
+   stream->in_buf_ptr = 0;
+
+   return true;
+}
+
+/* Writes 'len' bytes to an RZIP file.
+ * Returns actual number of bytes written, or -1
+ * in the event of an error */
+int64_t rzipstream_write(rzipstream_t *stream, const void *data, int64_t len)
+{
+   int64_t data_len        = len;
+   const uint8_t *data_ptr = (const uint8_t *)data;
+
+   if (!stream || !stream->is_writing || !data)
+      return -1;
+
+   /* Process input data */
+   while (data_len > 0)
+   {
+      uint32_t cache_size = 0;
+
+      /* If input buffer is full, compress and write to disk */
+      if (stream->in_buf_ptr >= stream->in_buf_size)
+         if (!rzipstream_write_chunk(stream))
+            return -1;
+
+      /* Get amount of data to cache during this loop
+       * > i.e. minimum of space remaining in input buffer
+       *   and remaining 'write data' size */
+      cache_size = stream->in_buf_size - stream->in_buf_ptr;
+      cache_size = (cache_size > data_len) ? data_len : cache_size;
+
+      /* Copy as much data as possible into
+       * the input buffer */
+      memcpy(stream->in_buf + stream->in_buf_ptr, data_ptr, cache_size);
+
+      /* Increment pointers and remaining length */
+      stream->in_buf_ptr  += cache_size;
+      data_ptr            += cache_size;
+      data_len            -= cache_size;
+
+      stream->size        += cache_size;
+      stream->virtual_ptr += cache_size;
+   }
+
+   /* We always write the specified number of bytes
+    * (unless rzipstream_write_chunk() fails, in
+    * which we register a complete failure...) */
+   return len;
+}
+
+/* Writes a single character to an RZIP file.
+ * Returns character written, or EOF in the event
+ * of an error */
+int rzipstream_putc(rzipstream_t *stream, int c)
+{
+   char c_char = (char)c;
+
+   if (!stream || !stream->is_writing)
+      return EOF;
+
+   return (rzipstream_write(stream, &c_char, 1) == 1) ?
+         (int)(unsigned char)c : EOF;
+}
+
+/* Writes a variable argument list to an RZIP file.
+ * Ugly 'internal' function, required to enable
+ * 'printf' support in the higher level 'interface_stream'.
+ * Returns actual number of bytes written, or -1
+ * in the event of an error */
+int rzipstream_vprintf(rzipstream_t *stream, const char* format, va_list args)
+{
+   static char buffer[8 * 1024] = {0};
+   int64_t num_chars            = vsprintf(buffer, format, args);
+
+   if (num_chars < 0)
+      return -1;
+   else if (num_chars == 0)
+      return 0;
+
+   return (int)rzipstream_write(stream, buffer, num_chars);
+}
+
+/* Writes formatted output to an RZIP file.
+ * Returns actual number of bytes written, or -1
+ * in the event of an error */
+int rzipstream_printf(rzipstream_t *stream, const char* format, ...)
+{
+   va_list vl;
+   int result = 0;
+
+   /* Initialise variable argument list */
+   va_start(vl, format);
+
+   /* Write variable argument list to file */
+   result = rzipstream_vprintf(stream, format, vl);
+
+   /* End using variable argument list */
+   va_end(vl);
+
+   return result;
+}
+
+/* Writes contents of 'data' buffer to file
+ * specified by 'path'.
+ * Returns false in the event of an error */
+bool rzipstream_write_file(const char *path, const void *data, int64_t len)
+{
+   int64_t bytes_written = 0;
+   rzipstream_t *stream  = NULL;
+
+   if (!data)
+      return false;
+
+   /* Attempt to open file */
+   stream = rzipstream_open(path, RETRO_VFS_FILE_ACCESS_WRITE);
+
+   if (!stream)
+   {
+      fprintf(stderr, "[rzipstream] Failed to open file: %s\n", path ? path : "");
+      return false;
+   }
+
+   /* Write contents of data buffer to file */
+   bytes_written = rzipstream_write(stream, data, len);
+
+   /* Close file */
+   if (rzipstream_close(stream) == -1)
+   {
+      fprintf(stderr, "[rzipstream] Failed to close file: %s\nData will be lost...\n", path);
+      return false;
+   }
+
+   /* Check that the correct number of bytes
+    * were written */
+   if (bytes_written != len)
+   {
+      fprintf(stderr, "[rzipstream] Wrote incorrect number of bytes to file: %s\n", path);
+      return false;
+   }
+
+   return true;
+}
+
+/* File Control */
+
+/* Sets file position to the beginning of the
+ * specified RZIP file.
+ * Note: It is not recommended to rewind a file
+ * that is open for writing, since the caller
+ * may end up with a file containing junk data
+ * at the end (harmless, but a waste of space). */
+void rzipstream_rewind(rzipstream_t *stream)
+{
+   if (!stream)
+      return;
+
+   /* Note: rzipstream_rewind() has no way of
+    * reporting errors (higher level interface
+    * requires a void return type) - so if anything
+    * goes wrong, all we can do is print to stderr
+    * and bail out... */
+
+   /* If we are handling uncompressed data, simply
+    * 'pass on' the direct file access request */
+   if (!stream->is_compressed)
+   {
+      filestream_rewind(stream->file);
+      return;
+   }
+
+   /* If no file access has yet occurred, file is
+    * already at the beginning -> do nothing */
+   if (stream->virtual_ptr == 0)
+      return;
+
+   /* Check whether we are reading or writing */
+   if (stream->is_writing)
+   {
+      /* Reset file position to first chunk location */
+      filestream_seek(stream->file, RZIP_HEADER_SIZE, SEEK_SET);
+      if (filestream_error(stream->file))
+      {
+         fprintf(
+               stderr,
+               "rzipstream_rewind(): Failed to reset file position...\n");
+         return;
+      }
+
+      /* Reset pointers */
+      stream->virtual_ptr = 0;
+      stream->in_buf_ptr  = 0;
+
+      /* Reset file size */
+      stream->size        = 0;
+   }
+   else
+   {
+      /* Check whether first file chunk is currently
+       * buffered in memory */
+      if ((stream->virtual_ptr < stream->chunk_size) &&
+          (stream->out_buf_ptr < stream->out_buf_occupancy))
+      {
+         /* It is: No file access is therefore required
+          * > Just reset pointers */
+         stream->virtual_ptr = 0;
+         stream->out_buf_ptr = 0;
+      }
+      else
+      {
+         /* It isn't: Have to re-read the first chunk
+          * from disk... */
+
+         /* Reset file position to first chunk location */
+         filestream_seek(stream->file, RZIP_HEADER_SIZE, SEEK_SET);
+         if (filestream_error(stream->file))
+         {
+            fprintf(
+                  stderr,
+                  "rzipstream_rewind(): Failed to reset file position...\n");
+            return;
+         }
+
+         /* Read chunk */
+         if (!rzipstream_read_chunk(stream))
+         {
+            fprintf(
+                  stderr,
+                  "rzipstream_rewind(): Failed to read first chunk of file...\n");
+            return;
+         }
+
+         /* Reset pointers */
+         stream->virtual_ptr = 0;
+         stream->out_buf_ptr = 0;
+      }
+   }
+}
+
+/* File Status */
+
+/* Returns total size (in bytes) of the *uncompressed*
+ * data in an RZIP file.
+ * (If reading an uncompressed file, this corresponds
+ * to the 'physical' file size in bytes)
+ * Returns -1 in the event of a error. */
+int64_t rzipstream_get_size(rzipstream_t *stream)
+{
+   if (!stream)
+      return -1;
+
+   if (stream->is_compressed)
+      return stream->size;
+   else
+      return filestream_get_size(stream->file);
+}
+
+/* Returns EOF when no further *uncompressed* data
+ * can be read from an RZIP file. */
+int rzipstream_eof(rzipstream_t *stream)
+{
+   if (!stream)
+      return -1;
+
+   if (stream->is_compressed)
+      return (stream->virtual_ptr >= stream->size) ?
+            EOF : 0;
+   else
+      return filestream_eof(stream->file);
+}
+
+/* Returns the offset of the current byte of *uncompressed*
+ * data relative to the beginning of an RZIP file.
+ * Returns -1 in the event of a error. */
+int64_t rzipstream_tell(rzipstream_t *stream)
+{
+   if (!stream)
+      return -1;
+
+   return (int64_t)stream->virtual_ptr;
+}
+
+/* Returns true if specified RZIP file contains
+ * compressed content */
+bool rzipstream_is_compressed(rzipstream_t *stream)
+{
+   if (!stream)
+      return false;
+
+   return stream->is_compressed;
+}
+
+/* File Close */
+
+/* Closes RZIP file. If file is open for writing,
+ * flushes any remaining buffered data to disk.
+ * Returns -1 in the event of a error. */
+int rzipstream_close(rzipstream_t *stream)
+{
+   if (!stream)
+      return -1;
+
+   /* If we are writing, ensure that any
+    * remaining uncompressed data is flushed to
+    * disk and update file header */
+   if (stream->is_writing)
+   {
+      if (stream->in_buf_ptr > 0)
+         if (!rzipstream_write_chunk(stream))
+            goto error;
+
+      if (!rzipstream_write_file_header(stream))
+         goto error;
+   }
+
+   /* Free stream
+    * > This also closes the file */
+   return rzipstream_free_stream(stream);
+
+error:
+   /* Stream must be free()'d regardless */
+   rzipstream_free_stream(stream);
+   return -1;
+}


### PR DESCRIPTION
This PR adds the new `rzip_stream` interface code. This is required since it is referenced in the recently updated `interface_stream` code (https://github.com/libretro/libretro-common/commit/48848f66f1822efa772dc5dd11f28e648736436d, https://github.com/libretro/libretro-common/commit/d23277f2b0798a7bbb710b7cdc83c0d55d94f61d)

The new `m3u_file` code is also added (seemed appropriate to do this here, since it is also file-related)