### PR TITLE
Mark co_switch_arm as thumb function when using thumb

### DIFF
--- a/libco/armeabi.c
+++ b/libco/armeabi.c
@@ -24,10 +24,13 @@ static thread_local cothread_t co_active_handle;
 
 __asm__ (
 #if defined(__thumb2__)
-      ".thumb\n"
       ".align 2\n"
       ".globl co_switch_arm\n"
       ".globl _co_switch_arm\n"
+      ".thumb\n"
+      ".thumb_func\n"
+      ".type   co_switch_arm, %function\n"
+      ".type   _co_switch_arm, %function\n"
       "co_switch_arm:\n"
       "_co_switch_arm:\n"
       " mov r3, sp\n"


### PR DESCRIPTION
Without this we end up trying to execute thumb code as arm which results
in a crash