### PR TITLE
Avoid returning a pointer onto the stack from zip_parse_file_iterate_step

### DIFF
--- a/file/archive_file.c
+++ b/file/archive_file.c
@@ -236,7 +236,7 @@ static int file_archive_extract_cb(const char *name, const char *valid_exts,
       {
          strlcpy(wanted_file, delim + 1, sizeof(wanted_file));
 
-         if (!string_is_equal_noncase(userdata->extracted_file_path,
+         if (!string_is_equal_noncase(userdata->current_file_path,
                    wanted_file))
            return 1; /* keep searching for the right file */
       }
@@ -524,8 +524,8 @@ bool file_archive_extract_file(
    struct string_list *list                 = string_split(valid_exts, "|");
 
    userdata.archive_path[0]                 = '\0';
+   userdata.current_file_path[0]            = '\0';
    userdata.first_extracted_file_path       = NULL;
-   userdata.extracted_file_path             = NULL;
    userdata.extraction_directory            = extraction_directory;
    userdata.archive_path_size               = archive_path_size;
    userdata.ext                             = list;
@@ -533,7 +533,6 @@ bool file_archive_extract_file(
    userdata.found_file                      = false;
    userdata.list_only                       = false;
    userdata.context                         = NULL;
-   userdata.archive_name[0]                 = '\0';
    userdata.crc                             = 0;
    userdata.dec                             = NULL;
 
@@ -587,8 +586,8 @@ struct string_list *file_archive_get_file_list(const char *path,
    struct archive_extract_userdata userdata;
 
    strlcpy(userdata.archive_path, path, sizeof(userdata.archive_path));
+   userdata.current_file_path[0]            = '\0';
    userdata.first_extracted_file_path       = NULL;
-   userdata.extracted_file_path             = NULL;
    userdata.extraction_directory            = NULL;
    userdata.archive_path_size               = 0;
    userdata.ext                             = NULL;
@@ -596,7 +595,6 @@ struct string_list *file_archive_get_file_list(const char *path,
    userdata.found_file                      = false;
    userdata.list_only                       = true;
    userdata.context                         = NULL;
-   userdata.archive_name[0]                 = '\0';
    userdata.crc                             = 0;
    userdata.dec                             = NULL;
 
@@ -869,7 +867,7 @@ uint32_t file_archive_get_file_crc32(const char *path)
       /* Stop when the right file in the archive is found. */
       if (archive_path)
       {
-         if (string_is_equal(userdata.extracted_file_path, archive_path))
+         if (string_is_equal(userdata.current_file_path, archive_path))
             break;
       }
       else

--- a/file/archive_file_7z.c
+++ b/file/archive_file_7z.c
@@ -464,7 +464,6 @@ static int sevenzip_parse_file_iterate_step(file_archive_transfer_t *state,
       const char *valid_exts,
       struct archive_extract_userdata *userdata, file_archive_file_cb file_cb)
 {
-   char filename[PATH_MAX_LENGTH];
    const uint8_t *cdata = NULL;
    uint32_t checksum    = 0;
    uint32_t size        = 0;
@@ -474,19 +473,18 @@ static int sevenzip_parse_file_iterate_step(file_archive_transfer_t *state,
    struct sevenzip_context_t *sevenzip_context = NULL;
    int ret;
 
-   filename[0]                   = '\0';
+   userdata->current_file_path[0] = '\0';
 
-   ret = sevenzip_parse_file_iterate_step_internal(state, filename,
+   ret = sevenzip_parse_file_iterate_step_internal(state, userdata->current_file_path,
          &cdata, &cmode, &size, &csize,
          &checksum, &payload, userdata);
 
    if (ret != 1)
       return ret;
 
-   userdata->extracted_file_path = filename;
    userdata->crc                 = checksum;
 
-   if (file_cb && !file_cb(filename, valid_exts, cdata, cmode,
+   if (file_cb && !file_cb(userdata->current_file_path, valid_exts, cdata, cmode,
             csize, size, checksum, userdata))
       return 0;
 

--- a/file/archive_file_zlib.c
+++ b/file/archive_file_zlib.c
@@ -339,6 +339,7 @@ static int zip_parse_file_iterate_step_internal(
       return -1;
 
    memcpy(filename, state->directory + 46, namelength); /* file name */
+   filename[namelength] = '\0';
 
    offset         = read_le(state->directory + 42, 4); /* relative offset of local file header */
    offsetNL       = read_le(state->data + offset + 26, 2); /* file name length */
@@ -355,7 +356,6 @@ static int zip_parse_file_iterate_step(file_archive_transfer_t *state,
       const char *valid_exts, struct archive_extract_userdata *userdata,
       file_archive_file_cb file_cb)
 {
-   char filename[PATH_MAX_LENGTH] = {0};
    const uint8_t *cdata           = NULL;
    uint32_t checksum              = 0;
    uint32_t size                  = 0;
@@ -363,15 +363,14 @@ static int zip_parse_file_iterate_step(file_archive_transfer_t *state,
    unsigned cmode                 = 0;
    unsigned payload               = 0;
    int ret                        = zip_parse_file_iterate_step_internal(
-         state, filename, &cdata, &cmode, &size, &csize, &checksum, &payload);
+         state, userdata->current_file_path, &cdata, &cmode, &size, &csize, &checksum, &payload);
 
    if (ret != 1)
       return ret;
 
-   userdata->extracted_file_path = filename;
    userdata->crc = checksum;
 
-   if (file_cb && !file_cb(filename, valid_exts, cdata, cmode,
+   if (file_cb && !file_cb(userdata->current_file_path, valid_exts, cdata, cmode,
             csize, size, checksum, userdata))
       return 0;
 

--- a/include/file/archive_file.h
+++ b/include/file/archive_file.h
@@ -105,8 +105,8 @@ typedef struct
 struct archive_extract_userdata
 {
    char archive_path[PATH_MAX_LENGTH];
+   char current_file_path[PATH_MAX_LENGTH];
    char *first_extracted_file_path;
-   char *extracted_file_path;
    const char *extraction_directory;
    size_t archive_path_size;
    struct string_list *ext;
@@ -114,7 +114,6 @@ struct archive_extract_userdata
    bool found_file;
    bool list_only;
    void *context;
-   char archive_name[PATH_MAX_LENGTH];
    uint32_t crc;
    struct decomp_state_t decomp_state;
    decompress_state_t *dec;


### PR DESCRIPTION
## Description

Avoid returning a pointer onto the stack from `zip_parse_file_iterate_step` and `sevenzip_parse_file_iterate_step`.
The pointer onto the stack was used after `archive_parse_file_iterate_step` returned, after `file_archive_parse_file_iterate` returned, inside `file_archive_get_file_crc32`.

This moves the array containing the filename into the archive_extract_userdata struct instead of storing a pointer there.

This PR also renames the member from `extracted_file_path` to `current_file_path` and removes the unused `archive_name` array from the archive_extract_userdata struct. The name `extracted_file_path` wasn't really correct as it is also used during iteration/walking over the archive.
I searched through all of github for "extracted_file_path" and through some front-end projects for "archive_name", it seems no one is using them. If you're worried about the change breaking things for someone somewhere I can revert the renaming/removal part.

## Related Issues

No real-world issues seem to exist (it has "worked" for at least 4 years) but better safe than sorry.
