### PR TITLE
Use ftello instead of ftell where available

### DIFF
--- a/vfs/vfs_implementation.c
+++ b/vfs/vfs_implementation.c
@@ -604,8 +604,10 @@ int64_t retro_vfs_file_tell_impl(libretro_vfs_implementation_file *stream)
       /* VC2005 and up have a special 64-bit ftell */
 #ifdef ATLEAST_VC2005
       return _ftelli64(stream->fp);
-#else
+#elif defined(__CELLOS_LV2__) || defined(_MSC_VER) && _MSC_VER <= 1310
       return ftell(stream->fp);
+#else
+      return ftello(stream->fp);
 #endif
 #endif
    }


### PR DESCRIPTION
Allows 64-bit file offsets on 32-bit platforms.
400 lines above my change, `fseeko` was already used and uses the same preprocessor condition.
So I'm quite confident that if ftello is available, fseeko also is and should be used.

I've successfully compiled RetroArch with -D_FILE_OFFSET_BITS=64 on a 32-bit ARM platform (Raspberry Pi) and loaded a 3 GB file with this. Without this filestream_get_size returned -1.