### PR TITLE
Fix vsnprintf between MSVC 2008 and 2013

### DIFF
--- a/include/compat/msvc.h
+++ b/include/compat/msvc.h
@@ -40,8 +40,8 @@ extern "C"  {
    int c99_snprintf_retro__(char *outBuf, size_t size, const char *format, ...);
 #endif
 
-/* Pre-MSVC 2008 compilers don't implement vsnprintf in a cross-platform manner? Not sure about this one. */
-#if _MSC_VER < 1500
+/* Pre-MSVC 2015 compilers don't implement vsnprintf in a cross-platform manner */
+#if _MSC_VER < 1900
    #include <stdio.h>
    #include <stdarg.h>
    #include <stdlib.h>

--- a/include/compat/msvc.h
+++ b/include/compat/msvc.h
@@ -29,22 +29,17 @@
 extern "C"  {
 #endif
 
-/* Pre-MSVC 2015 compilers don't implement snprintf in a cross-platform manner. */
-#if _MSC_VER < 1900
-   #include <stdio.h>
-   #include <stdlib.h>
-   #ifndef snprintf
-      #define snprintf c99_snprintf_retro__
-   #endif
-
-   int c99_snprintf_retro__(char *outBuf, size_t size, const char *format, ...);
-#endif
-
-/* Pre-MSVC 2015 compilers don't implement vsnprintf in a cross-platform manner */
+/* Pre-MSVC 2015 compilers don't implement snprintf, vsnprintf in a cross-platform manner. */
 #if _MSC_VER < 1900
    #include <stdio.h>
    #include <stdarg.h>
    #include <stdlib.h>
+
+   #ifndef snprintf
+      #define snprintf c99_snprintf_retro__
+   #endif
+   int c99_snprintf_retro__(char *outBuf, size_t size, const char *format, ...);
+
    #ifndef vsnprintf
       #define vsnprintf c99_vsnprintf_retro__
    #endif


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/vsnprintf-vsnprintf-vsnprintf-l-vsnwprintf-vsnwprintf-l only starting in MSVC 2015 vsnprintf complies with the C99 standard. Before that, vsnprintf was available but did not NULL terminate a string that got filled up. This would lead to program crashes with overflowing strings. Tested on MSVC 2013.

Relevant excerpts from the documentation:
> When using _vsnprintf and _vsnwprintf, the buffer will be null-terminated only if there's room at the end

> Beginning with the UCRT in Visual Studio 2015 and Windows 10, vsnprintf is no longer identical to _vsnprintf. The vsnprintf function complies with the C99 standard.