### PR TITLE
Remove trailing slash from dir for gekko systems

### DIFF
--- a/file/file_path_io.c
+++ b/file/file_path_io.c
@@ -209,13 +209,13 @@ bool path_mkdir(const char *dir)
        * We also remove the slash from dir
        * so the directory is created properly.
        * This is necessary when a path containing a
-       * trailing slash is passed to path_mkdir() */
+       * trailing slash is passed to path_mkdir(). */
       if (len > 0)
          if (basedir[len - 1] == '/')
             basedir[len - 1] = '\0';
       if (len2 > 0)
-         if (dir[len - 1] == '/')
-            dir[len - 1] = '\0';
+         if (dir[len2 - 1] == '/')
+            dir[len2 - 1] = '\0';
    }
 #endif
 

--- a/file/file_path_io.c
+++ b/file/file_path_io.c
@@ -199,15 +199,23 @@ bool path_mkdir(const char *dir)
 
 #if defined(GEKKO)
    {
-      size_t len = strlen(basedir);
+      size_t len  = strlen(basedir);
+      size_t len2 = strlen(dir);
 
       /* path_parent_dir() keeps the trailing slash.
        * On Wii, mkdir() fails if the path has a
        * trailing slash...
-       * We must therefore remove it. */
+       * We must therefore remove it.
+       * We also remove the slash from dir
+       * so the directory is created properly.
+       * This is necessary when a path containing a
+       * trailing slash is passed to path_mkdir() */
       if (len > 0)
          if (basedir[len - 1] == '/')
             basedir[len - 1] = '\0';
+      if (len2 > 0)
+         if (dir[len - 1] == '/')
+            dir[len - 1] = '\0';
    }
 #endif
 


### PR DESCRIPTION
Fix for #161. dir is the path we are trying to create. wiiu can not create a directory path containing a trailing slash so we must remove it for directory creation to work properly for gekko systems.