### PR TITLE
Fix MSVC pre-2015 vsnprintf crash

### DIFF
--- a/compat/compat_snprintf.c
+++ b/compat/compat_snprintf.c
@@ -62,7 +62,7 @@ int c99_vsnprintf_retro__(char *outBuf, size_t size, const char *format, va_list
    if (count == -1)
        count = _vscprintf(format, ap);
 
-   if (count == size)
+   if (count == size && size)
    {
       /* there was no room for a NULL, so truncate the last character */
       outBuf[size - 1] = '\0';


### PR DESCRIPTION
According to the C standard, vsnprintf should accept a 0 length size parameter.

Without this fix, the following code crashes the program:
```c
snprintf(NULL, 0, "");
```

One feature of the function is to measure the bytes needed to encode a format string is by calling it with such a  `NULL, 0` pair. 
While a format of "" might not be a realistic usage of snprintf, something like `("%s", str)` or `("%*.s", count, "")` is.

The relevant C standard excerpt:
>    The snprintf function is equivalent to fprintf, except that the output is
>    written into an array (specified by argument s) rather than to a stream. If
>    n is zero, nothing is written, and s may be a null pointer. Otherwise,
>    output characters beyond the n-1st are discarded rather than being written
>    to the array, and a null character is written at the end of the characters
>    actually written into the array.
