### PR TITLE
Fix dir creation for Wii - gekko based systems

### DIFF
--- a/file/file_path_io.c
+++ b/file/file_path_io.c
@@ -209,6 +209,8 @@ bool path_mkdir(const char *dir)
       if (len > 0)
          if (basedir[len - 1] == '/')
             basedir[len - 1] = '\0';
+
+      free(len);
    }
 #endif
 
@@ -230,12 +232,14 @@ bool path_mkdir(const char *dir)
 
 #if defined(GEKKO)
    {
-      /* Trim trailing slash for Wii */
+      /* Trim trailing slash for WiiU */
       size_t len2 = strlen(makedir);
 
       if (len2 > 0)
          if (makedir[len2 - 1] == '/')
             makedir[len2 - 1] = '\0';
+
+      free(len2);
    }
 #endif
 

--- a/file/file_path_io.c
+++ b/file/file_path_io.c
@@ -165,6 +165,16 @@ int32_t path_get_size(const char *path)
    return -1;
 }
 
+static void no_slash (char* temp)
+{
+  int i;
+
+  for(i=0; temp[i] != '\0'; ++i);
+
+  if(temp[i-1] == '/')
+    temp[i-1] = '\0';
+}
+
 /**
  * path_mkdir:
  * @dir                : directory
@@ -173,12 +183,11 @@ int32_t path_get_size(const char *path)
  *
  * Returns: true (1) if directory could be created, otherwise false (0).
  **/
-bool path_mkdir(const char *dir)
+bool path_mkdir(char *dir)
 {
    bool         sret  = false;
    bool norecurse     = false;
    char     *basedir  = NULL;
-   char     *newdir   = NULL;
 
    if (!(dir && *dir))
       return false;
@@ -197,20 +206,8 @@ bool path_mkdir(const char *dir)
       free(basedir);
       return false;
    }
-
-#if defined(GEKKO)
-   {
-      size_t len = strlen(basedir);
-
-      /* path_parent_dir() keeps the trailing slash.
-       * On Wii, mkdir() fails if the path has a
-       * trailing slash...
-       * We must therefore remove it. */
-      if (len > 0)
-         if (basedir[len - 1] == '/')
-            basedir[len - 1] = '\0';
-   }
-#endif
+   /* No trailing slash - implemented for WiiU */
+   no_slash(basedir);
 
    if (path_is_directory(basedir))
       norecurse = true;
@@ -230,27 +227,19 @@ bool path_mkdir(const char *dir)
       if (!newdir)
         return false;
 
-#if defined(GEKKO)
-   {
-      /* Trim trailing slash for WiiU */
-      size_t len2 = strlen(newdir);
+      /* No trailing slash - implemented for WiiU */
+      no_slash(dir);
 
-      if (len2 > 0)
-         if (newdir[len2 - 1] == '/')
-            newdir[len2 - 1] = '\0';
-   }
-#endif
-
-      int ret = path_mkdir_cb(newdir);
+      int ret = path_mkdir_cb(dir);
 
       /* Don't treat this as an error. */
-      if (ret == -2 && path_is_directory(newdir))
+      if (ret == -2 && path_is_directory(dir))
       {
-         free(newdir);
+         free(dir);
          return true;
       }
 
-      free(newdir);
+      free(dir);
       return (ret == 0);
    }
 

--- a/file/file_path_io.c
+++ b/file/file_path_io.c
@@ -223,10 +223,6 @@ bool path_mkdir(char *dir)
 
    if (norecurse)
    {
-      newdir = strdup(dir);
-      if (!newdir)
-        return false;
-
       /* No trailing slash - implemented for WiiU */
       no_slash(dir);
 

--- a/file/file_path_io.c
+++ b/file/file_path_io.c
@@ -178,7 +178,7 @@ bool path_mkdir(const char *dir)
    bool         sret  = false;
    bool norecurse     = false;
    char     *basedir  = NULL;
-   char     *makedir  = NULL;
+   char     *newdir   = NULL;
 
    if (!(dir && *dir))
       return false;
@@ -228,25 +228,25 @@ bool path_mkdir(const char *dir)
 
    if (norecurse)
    {
-      makedir = strdup(dir);
+      newdir = strdup(dir);
 
 #if defined(GEKKO)
    {
       /* Trim trailing slash for WiiU */
-      size_t len2 = strlen(makedir);
+      size_t len2 = strlen(newdir);
 
       if (len2 > 0)
-         if (makedir[len2 - 1] == '/')
-            makedir[len2 - 1] = '\0';
+         if (newdir[len2 - 1] == '/')
+            newdir[len2 - 1] = '\0';
 
       free(len2);
    }
 #endif
 
-      int ret = path_mkdir_cb(makedir);
+      int ret = path_mkdir_cb(newdir);
 
       /* Don't treat this as an error. */
-      if (ret == -2 && path_is_directory(makedir))
+      if (ret == -2 && path_is_directory(newdir))
          return true;
 
       return (ret == 0);

--- a/file/file_path_io.c
+++ b/file/file_path_io.c
@@ -209,8 +209,6 @@ bool path_mkdir(const char *dir)
       if (len > 0)
          if (basedir[len - 1] == '/')
             basedir[len - 1] = '\0';
-
-      free(len);
    }
 #endif
 
@@ -238,8 +236,6 @@ bool path_mkdir(const char *dir)
       if (len2 > 0)
          if (newdir[len2 - 1] == '/')
             newdir[len2 - 1] = '\0';
-
-      free(len2);
    }
 #endif
 
@@ -247,10 +243,15 @@ bool path_mkdir(const char *dir)
 
       /* Don't treat this as an error. */
       if (ret == -2 && path_is_directory(newdir))
+      {
+         free(newdir);
          return true;
+      }
 
+      free(newdir);
       return (ret == 0);
    }
 
+   free(newdir);
    return sret;
 }

--- a/file/file_path_io.c
+++ b/file/file_path_io.c
@@ -207,8 +207,9 @@ bool path_mkdir(char *dir)
       return false;
    }
 
-   /* No trailing slash - implemented for WiiU */
+#if defined(GEKKO)
    no_slash(basedir);
+#endif
 
    if (path_is_directory(basedir))
       norecurse = true;
@@ -224,8 +225,9 @@ bool path_mkdir(char *dir)
 
    if (norecurse)
    {
-      /* No trailing slash - implemented for WiiU */
+#if defined(GEKKO)
       no_slash(dir);
+#endif
 
       int ret = path_mkdir_cb(dir);
 

--- a/file/file_path_io.c
+++ b/file/file_path_io.c
@@ -252,6 +252,5 @@ bool path_mkdir(const char *dir)
       return (ret == 0);
    }
 
-   free(newdir);
    return sret;
 }

--- a/file/file_path_io.c
+++ b/file/file_path_io.c
@@ -206,6 +206,7 @@ bool path_mkdir(char *dir)
       free(basedir);
       return false;
    }
+
    /* No trailing slash - implemented for WiiU */
    no_slash(basedir);
 

--- a/file/file_path_io.c
+++ b/file/file_path_io.c
@@ -227,6 +227,8 @@ bool path_mkdir(const char *dir)
    if (norecurse)
    {
       newdir = strdup(dir);
+      if (!newdir)
+        return false;
 
 #if defined(GEKKO)
    {

--- a/file/file_path_io.c
+++ b/file/file_path_io.c
@@ -178,6 +178,7 @@ bool path_mkdir(const char *dir)
    bool         sret  = false;
    bool norecurse     = false;
    char     *basedir  = NULL;
+   char     *makedir  = NULL;
 
    if (!(dir && *dir))
       return false;
@@ -225,10 +226,23 @@ bool path_mkdir(const char *dir)
 
    if (norecurse)
    {
-      int ret = path_mkdir_cb(dir);
+      makedir = strdup(dir);
+
+#if defined(GEKKO)
+   {
+      /* Trim trailing slash for Wii */
+      size_t len2 = strlen(makedir);
+
+      if (len2 > 0)
+         if (makedir[len2 - 1] == '/')
+            makedir[len2 - 1] = '\0';
+   }
+#endif
+
+      int ret = path_mkdir_cb(makedir);
 
       /* Don't treat this as an error. */
-      if (ret == -2 && path_is_directory(dir))
+      if (ret == -2 && path_is_directory(makedir))
          return true;
 
       return (ret == 0);

--- a/file/file_path_io.c
+++ b/file/file_path_io.c
@@ -230,12 +230,8 @@ bool path_mkdir(char *dir)
 
       /* Don't treat this as an error. */
       if (ret == -2 && path_is_directory(dir))
-      {
-         free(dir);
          return true;
-      }
 
-      free(dir);
       return (ret == 0);
    }
 


### PR DESCRIPTION
Trims trailing slash when dir is created for gekko based systems. Issue noted in #161.