### PR TITLE
Improve ARM runtime feature detection on Linux

### DIFF
--- a/features/features_cpu.c
+++ b/features/features_cpu.c
@@ -337,8 +337,27 @@ static void arm_enable_runfast_mode(void)
 #endif
 
 #if defined(__linux__) && !defined(CPU_X86)
+#if __ARM_ARCH
+#include <sys/auxv.h>
+#endif
+
 static unsigned char check_arm_cpu_feature(const char* feature)
 {
+#if __ARM_ARCH < 8
+   uint64_t hwcap = getauxval(AT_HWCAP);
+   if (!strcmp(feature, "neon"))
+      return (hwcap & HWCAP_ARM_NEON) != 0;
+   if (!strcmp(feature, "vfpv3"))
+      return (hwcap & HWCAP_ARM_VFPv3) != 0;
+   if (!strcmp(feature, "vfpv4"))
+      return (hwcap & HWCAP_ARM_VFPv4) != 0;
+   return 0;
+#elif __ARM_ARCH == 8
+   uint64_t hwcap = getauxval(AT_HWCAP);
+   if (!strcmp(feature, "asimd"))
+      return (hwcap & HWCAP_ASIMD) != 0;
+   return 0;
+#else
    char line[1024];
    unsigned char status = 0;
    RFILE *fp = filestream_open("/proc/cpuinfo",
@@ -362,6 +381,7 @@ static unsigned char check_arm_cpu_feature(const char* feature)
    filestream_close(fp);
 
    return status;
+#endif
 }
 
 #if !defined(_SC_NPROCESSORS_ONLN)


### PR DESCRIPTION
`getauxval(AT_HWCAP)` is the best way to check for features on ARM and AArch64, as it doesn’t require parsing a file, instead it just returns a value provided by the kernel in our address space.