### PR TITLE
Fix undefined macro causing build to fail on some platforms

### DIFF
--- a/gfx/scaler/pixconv.c
+++ b/gfx/scaler/pixconv.c
@@ -29,7 +29,7 @@
 
 #include <gfx/scaler/pixconv.h>
 
-#if _MSC_VER && _MSC_VER <= 1800
+#if defined(_MSC_VER) && _MSC_VER <= 1800
 #define SCALER_NO_SIMD
 #endif
 


### PR DESCRIPTION
This file wouldn't build when using Unreal Engine's Android toolchain. 
I think the intended behavior was to short-circuit when `_MSC_VER` isn't defined which I've modified it to do.