### PR TITLE
fix uncompr.c compilation

### DIFF
--- a/include/compat/zlib.h
+++ b/include/compat/zlib.h
@@ -1196,8 +1196,8 @@ typedef int (*out_func) (void FAR *, unsigned char FAR *, unsigned);
    compress() or compress2() call to allocate the destination buffer.
 */
 
- int  uncompress (unsigned char *dest,   uint32_t *destLen,
-       const unsigned char *source, uint32_t sourceLen);
+ int  uncompress (Bytef *dest,   uLongf *destLen,
+       const Bytef *source, uLongf sourceLen);
 /*
      Decompresses the source buffer into the destination buffer.  sourceLen is
    the byte length of the source buffer.  Upon entry, destLen is the total size

--- a/include/compat/zlib/zlib.h
+++ b/include/compat/zlib/zlib.h
@@ -1190,8 +1190,8 @@ typedef int (*out_func) (void FAR *, unsigned char FAR *, unsigned);
    compress() or compress2() call to allocate the destination buffer.
 */
 
- int  uncompress (unsigned char *dest,   uint32_t *destLen,
-       const unsigned char *source, uint32_t sourceLen);
+ int  uncompress (Bytef *dest,   uLongf *destLen,
+       const Bytef *source, uLongf sourceLen);
 /*
      Decompresses the source buffer into the destination buffer.  sourceLen is
    the byte length of the source buffer.  Upon entry, destLen is the total size


### PR DESCRIPTION
commit d9ee8e3ec1dca2b6d1a9bc3c71d56ef6f0d23ef0 broke uncompr.c compilation because of uncompress() declaration and definition type missmatch