### PR TITLE
Replace union with struct in audio_mixer_voice

### DIFF
--- a/audio/audio_mixer.c
+++ b/audio/audio_mixer.c
@@ -117,7 +117,7 @@ struct audio_mixer_sound
 
 struct audio_mixer_voice
 {
-   union
+   struct
    {
       struct
       {


### PR DESCRIPTION
audio_mixer_play_ogg calls stb_vorbis_close if types.ogg.stream is set
but it overlaps with wav.position and stb_vorbis_close ends up freeing
unallocated space and crashing

Space saving is minor, so let's just split the variants