### PR TITLE
Add guard for empty ogg stream

### DIFF
--- a/audio/audio_mixer.c
+++ b/audio/audio_mixer.c
@@ -998,6 +998,9 @@ static void audio_mixer_mix_ogg(float* buffer, size_t num_frames,
    unsigned temp_samples            = 0;
    float* pcm                       = NULL;
 
+   if (!voice->types.ogg.stream)
+      return;
+
    if (voice->types.ogg.position == voice->types.ogg.samples)
    {
 again:


### PR DESCRIPTION
It's sometimes NULL. Most likely because load and decode are done separately
and so it may be loaded but not even decoded yet

@twinaphex 