### PR TITLE
Ensure task_queue_wait(NULL,NULL) calls callbacks

### DIFF
--- a/queues/task_queue.c
+++ b/queues/task_queue.c
@@ -424,6 +424,8 @@ static void retro_task_threaded_wait(retro_task_condition_fn_t cond, void* data)
       wait = (tasks_running.front && !tasks_running.front->when);
       slock_unlock(running_lock);
    } while (wait && (!cond || cond(data)));
+   
+   retro_task_threaded_gather();
 }
 
 static void retro_task_threaded_reset(void)


### PR DESCRIPTION
I've faced with a bug when user launches netplay with relay server setting is on, but still getting "You room couldn't be connected" message. After debugging I found out that in 70% cases on my machine the `netplay_announce()` is done with empty `mitm_session=`. On its turn this was due to the fact that in `netplay_mitm_query()` the code
```
      if (!task_push_http_transfer(query,
            true, NULL, netplay_mitm_query_cb, NULL))
         return false;

      /* Make sure we've the tunnel address before continuing. */
      task_queue_wait(NULL, NULL);
```

ends before callback `netplay_mitm_query_cb` is invoked and retroarch continues without mitm data, which is equal to disabled relay server option. Which means `task_queue_wait(NULL, NULL);` returns without calling a task's callback in spite of the commentary.   
There is a loop:
```
   do
   {
      retro_task_threaded_gather();

      slock_lock(running_lock);
      wait = (tasks_running.front && !tasks_running.front->when);
      slock_unlock(running_lock);
   } while (wait && (!cond || cond(data)));
```
And it seems that task could be finished after `retro_task_threaded_gather();` but before `wait = (tasks_running.front && !tasks_running.front->when);`. This will end the loop, and at this point the tasks_running will be empty, and tasks_finished will contain a finished task. But its callback won't be invoked bcs this happens in `retro_task_threaded_gather();`.

Perhaps there is a better solution but I workarounded this issue by just adding one more call to the `retro_task_threaded_gather();` after the loop ends.

My system is Kubuntu 21.10. Retroarch pulled from github.
`$ uname -a
Linux laptop 5.13.0-35-generic #40-Ubuntu SMP Mon Mar 7 08:03:10 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux`