### PR TITLE
Create ChipTune-Lowpass.dsp

### DIFF
--- a/audio/dsp_filters/ChipTune-Lowpass.dsp
+++ b/audio/dsp_filters/ChipTune-Lowpass.dsp
@@ -1,0 +1,7 @@
+filters = 1
+filter0 = iir
+
+iir_frequency = 8600.0
+iir_quality = 0.707
+iir_gain = 6.0
+iir_type = LPF


### PR DESCRIPTION
This adds a good general-purpose lowpass filter for chiptunes to tame some of the nastier high-pitched sounds. Taken from this forum post: https://forums.libretro.com/t/lowpass-filtering-for-nes-rf/37258/9