### PR TITLE
Detect `ARM` rather than exclude `x86` for `ARM` specific code

### DIFF
--- a/features/features_cpu.c
+++ b/features/features_cpu.c
@@ -272,6 +272,9 @@ retro_time_t cpu_features_get_time_usec(void)
 
 #if defined(__x86_64__) || defined(__i386__) || defined(__i486__) || defined(__i686__) || (defined(_M_X64) && _MSC_VER > 1310) || (defined(_M_IX86) && _MSC_VER > 1310)
 #define CPU_X86
+#elif defined(__ARM_ARCH) || defined(__TARGET_ARCH_ARM) || defined(_M_ARM) || defined(__arm__) || \
+      defined(__arm64) || defined(_M_ARM64) || defined(__aarch64__) || defined(__AARCH64EL__)
+#define CPU_ARM
 #endif
 
 #if defined(_MSC_VER) && !defined(_XBOX)
@@ -356,7 +359,7 @@ static void arm_enable_runfast_mode(void)
 #endif
 #endif
 
-#if defined(__linux__) && !defined(CPU_X86)
+#if defined(__linux__) && defined(CPU_ARM)
 static unsigned char check_arm_cpu_feature(const char* feature)
 {
    char line[1024];


### PR DESCRIPTION
I'm compiling a project for RISC-V 64-bit that depends on `libretro-common`, and I got errors:

```
../desmume/desmume/src/libretro-common/features/features_cpu.c:321:31: error: ‘AT_HWCAP’ undeclared (first use in this function)
  321 |    uint64_t hwcap = getauxval(AT_HWCAP);
      |                               ^~~~~~~~
../desmume/desmume/src/libretro-common/features/features_cpu.c:321:31: note: each undeclared identifier is reported only once for each function it appears in
../desmume/desmume/src/libretro-common/features/features_cpu.c:323:23: error: ‘HWCAP_ARM_NEON’ undeclared (first use in this function)
  323 |       return (hwcap & HWCAP_ARM_NEON) != 0;
      |                       ^~~~~~~~~~~~~~
../desmume/desmume/src/libretro-common/features/features_cpu.c:325:23: error: ‘HWCAP_ARM_VFPv3’ undeclared (first use in this function)
  325 |       return (hwcap & HWCAP_ARM_VFPv3) != 0;
      |                       ^~~~~~~~~~~~~~~
../desmume/desmume/src/libretro-common/features/features_cpu.c:327:23: error: ‘HWCAP_ARM_VFPv4’ undeclared (first use in this function)
  327 |       return (hwcap & HWCAP_ARM_VFPv4) != 0;
      |                       ^~~~~~~~~~~~~~~
```

It indicates that it is incorrectly entering an ARM specific code path.

This PR changed the macro condition of ARM specific code from `!defined(CPU_X86)` to `defined(CPU_ARM)` to support it compiling for more other architectures.

The ARM detection code is referenced from https://github.com/boostorg/predef/blob/499d28e34f78950ede62fdb9b74cbe06eb5fdf96/include/boost/predef/architecture/arm.h#L73-L83.