### PR TITLE
rthreads: include sys/time.h for mips and 3ds

### DIFF
--- a/rthreads/rthreads.c
+++ b/rthreads/rthreads.c
@@ -55,7 +55,7 @@
 #include <time.h>
 #endif
 
-#if defined(VITA) || defined(BSD) || defined(ORBIS)
+#if defined(VITA) || defined(BSD) || defined(ORBIS) || defined(__mips__) || defined(_3DS)
 #include <sys/time.h>
 #endif
 


### PR DESCRIPTION
this is to cover all platforms where struct timeval is used