### PR TITLE
Wait until there is any work item to be done

### DIFF
--- a/rthreads/tpool.c
+++ b/rthreads/tpool.c
@@ -258,7 +258,7 @@ void tpool_wait(tpool_t *tp)
       /* working_cond is dual use. It signals when we're not stopping but the
        * working_cnt is 0 indicating there isn't any work processing. If we
        * are stopping it will trigger when there aren't any threads running. */
-      if ((!tp->stop && tp->working_cnt != 0) || (tp->stop && tp->thread_cnt != 0))
+      if ((!tp->stop && (tp->working_cnt != 0 || tm->work_first != NULL)) || (tp->stop && tp->thread_cnt != 0))
          scond_wait(tp->working_cond, tp->work_mutex);
       else
          break;


### PR DESCRIPTION
This is for handling a rare case when all threads are free without any work (working_cnt == 0) but there exist some work items that are not yet done or not yet started to be processed.

I'm using your code (first I took it from your blog) in my program. It was very useful. However I noticed that when I use 1 or 2 threads the pool thread will finish without any doing any job.I'm calling `tpool_wait` right after adding all works (I had only one or two work items to add for that specific example) so the function, `tpool_wait`, locks the mutex prior to any working thread takes the mutex. In that case `(!tm->stop && tm->working_cnt != 0)` is false so it will not call `pthread_cond_wait(&(tm->working_cond), &(tm->work_mutex))` and exit immediately. Then I call `tpool_destroy` right after that and it will take the mutex and this is all happening before any working thread takes the mutex and does any job. Therefore all jobs are canceled by `tpool_destroy`. I guess this is only happening when we have low number of work items to add so there is not much time for the working threads to take the mutex.
I think this small change can make the code more robust to such rare conditions.