### PR TITLE
file_path.c: Silence warning (-Wunused-variable)

### DIFF
--- a/file/file_path.c
+++ b/file/file_path.c
@@ -74,7 +74,9 @@
 void strftime_am_pm(char *s, size_t len, const char* format,
       const void *ptr)
 {
+#if !(defined(__linux__) && !defined(ANDROID))
    char *local = NULL;
+#endif
    const struct tm *timeptr = (const struct tm*)ptr;
 
    /* Ensure correct locale is set


### PR DESCRIPTION
CC libretro/libretro-common/encodings/encoding_utf.c CC libretro/libretro-common/file/file_path.c
libretro/libretro-common/file/file_path.c: In function ‘strftime_am_pm’: libretro/libretro-common/file/file_path.c:77:10: warning: unused variable ‘local’ [-Wunused-variable]
   77 |    char *local = NULL;
      |          ^~~~~
CC libretro/libretro-common/file/file_path_io.c
CC libretro/libretro-common/streams/file_stream.c