### PR TITLE
Add support for writing gzip files in trans_stream_zlib

### DIFF
--- a/streams/trans_stream_zlib.c
+++ b/streams/trans_stream_zlib.c
@@ -30,7 +30,8 @@
 struct zlib_trans_stream
 {
    z_stream z;
-   int ex; /* window_bits or level */
+   int window_bits;
+   int level;
    bool inited;
 };
 
@@ -41,7 +42,8 @@ static void *zlib_deflate_stream_new(void)
    if (!ret)
       return NULL;
    ret->inited      = false;
-   ret->ex          = 9;
+   ret->level       = 9;
+   ret->window_bits = 15;
 
    ret->z.next_in   = NULL;
    ret->z.avail_in  = 0;
@@ -70,7 +72,7 @@ static void *zlib_inflate_stream_new(void)
    if (!ret)
       return NULL;
    ret->inited      = false;
-   ret->ex          = MAX_WBITS;
+   ret->window_bits = MAX_WBITS;
 
    ret->z.next_in   = NULL;
    ret->z.avail_in  = 0;
@@ -115,23 +117,29 @@ static void zlib_inflate_stream_free(void *data)
 
 static bool zlib_deflate_define(void *data, const char *prop, uint32_t val)
 {
+   if (!data)
+      return false;
+
    struct zlib_trans_stream *z = (struct zlib_trans_stream *) data;
    if (string_is_equal(prop, "level"))
-   {
-      if (z)
-         z->ex = (int) val;
-      return true;
-   }
-   return false;
+      z->level = (int) val;
+   else if (string_is_equal(prop, "window_bits"))
+      z->window_bits = (int) val;
+   else
+      return false;
+
+   return true;
 }
 
 static bool zlib_inflate_define(void *data, const char *prop, uint32_t val)
 {
+   if (!data)
+      return false;
+
    struct zlib_trans_stream *z = (struct zlib_trans_stream *) data;
    if (string_is_equal(prop, "window_bits"))
    {
-      if (z)
-         z->ex = (int) val;
+      z->window_bits = (int) val;
       return true;
    }
    return false;
@@ -149,7 +157,7 @@ static void zlib_deflate_set_in(void *data, const uint8_t *in, uint32_t in_size)
 
    if (!z->inited)
    {
-      deflateInit(&z->z, z->ex);
+      deflateInit2(&z->z, z->level, Z_DEFLATED , z->window_bits, 8,  Z_DEFAULT_STRATEGY );
       z->inited = true;
    }
 }
@@ -165,7 +173,7 @@ static void zlib_inflate_set_in(void *data, const uint8_t *in, uint32_t in_size)
    z->z.avail_in               = in_size;
    if (!z->inited)
    {
-      inflateInit2(&z->z, z->ex);
+      inflateInit2(&z->z, z->window_bits);
       z->inited = true;
    }
 }
@@ -195,7 +203,7 @@ static bool zlib_deflate_trans(
 
    if (!zt->inited)
    {
-      deflateInit(z, zt->ex);
+      deflateInit2(z, zt->level, Z_DEFLATED , zt->window_bits, 8,  Z_DEFAULT_STRATEGY );
       zt->inited = true;
    }
 
@@ -258,7 +266,7 @@ static bool zlib_inflate_trans(
 
    if (!zt->inited)
    {
-      inflateInit2(z, zt->ex);
+      inflateInit2(z, zt->window_bits);
       zt->inited = true;
    }
 


### PR DESCRIPTION
Reading `*.gz` files was already possible by supplying a fitting `windows_bits` of 31 for instance.
https://www.zlib.net/manual.html

> windowBits can also be greater than 15 for optional gzip encoding. Add 16 to windowBits to write a simple gzip header and trailer around the compressed data instead of a zlib wrapper. The gzip header will have no file name, no extra data, no comment, no modification time (set to zero), no header crc, and the operating system will be set to the appropriate value, if the operating system was determined at compile time. If a gzip stream is being written, strm->adler is a CRC-32 instead of an Adler-32.


For compression it is also possible to write a gzip header:
> windowBits can also be greater than 15 for optional gzip decoding. Add 32 to windowBits to enable zlib and gzip decoding with automatic header detection, or add 16 to decode only the gzip format (the zlib format will return a Z_DATA_ERROR). If a gzip stream is being decoded, strm->adler is a CRC-32 instead of an Adler-32. Unlike the gunzip utility and gzread() (see below), inflate() will not automatically decode concatenated gzip members. inflate() will return Z_STREAM_END at the end of the gzip member. The state would need to be reset to continue decoding a subsequent gzip member. This must be done if there is more data after a gzip member, in order for the decompression to be compliant with the gzip standard (RFC 1952).

But trans_stream_zlib doesn't support setting `window_bits` for compression. Only `level` was supported as there was only one generic `ex` member in `zlib_trans_stream` to store things in.

I created dedicated variables to store compression `level` and `window_bits` and allowed setting the latter for compression too. This way you can have the stream write a proper gzip file.

The client interface is backwards compatible.