### PR TITLE
Fix a build error on iOS

### DIFF
--- a/dynamic/dylib.c
+++ b/dynamic/dylib.c
@@ -24,6 +24,9 @@
 #include <stdio.h>
 #include <dynamic/dylib.h>
 #include <encodings/utf.h>
+#include <string/stdstring.h>
+#include <retro_miscellaneous.h>
+#include <file/file_path.h>
 
 #if defined(ORBIS)
 #include <orbis/libkernel.h>
@@ -127,7 +130,7 @@ dylib_t dylib_load(const char *path)
 #elif defined(ORBIS)
    int res;
    dylib_t lib = (dylib_t)sceKernelLoadStartModule(path, 0, NULL, 0, NULL, &res);
-#elif IOS
+#elif defined(IOS)
     dylib_t lib;
     static const char fw_suffix[] = ".framework";
     if (string_ends_with(path, fw_suffix))


### PR DESCRIPTION
- Includes certain newly-required headers
- Makes the use of the `IOS` macro consistent with other platform checks