### PR TITLE
add apparent missing includes in ctr_pthread

### DIFF
--- a/rthreads/ctr_pthread.h
+++ b/rthreads/ctr_pthread.h
@@ -26,6 +26,8 @@
 #include <3ds/thread.h>
 #include <3ds/synchronization.h>
 #include <3ds/svc.h>
+#include <3ds/services/apt.h>
+#include <sys/time.h>
 #include <time.h>
 #include <errno.h>
 #include <retro_inline.h>


### PR DESCRIPTION
considering to use rthreads in pcsx_rearmed