### PR TITLE
Patch CVE-2025-9809

### DIFF
--- a/formats/cdfs/cdfs.c
+++ b/formats/cdfs/cdfs.c
@@ -468,8 +468,13 @@ static cdfs_track_t* cdfs_open_cue_track(
                --file_end;
             }
 
-            memcpy(current_track_path, file, file_end - file);
-            current_track_path[file_end - file] = '\0';
+            if (file_end - file < PATH_MAX_LENGTH) {
+               memcpy(current_track_path, file, file_end - file);
+               current_track_path[file_end - file] = '\0';
+            } else {
+               memcpy(current_track_path, file, PATH_MAX_LENGTH - 1);
+               current_track_path[PATH_MAX_LENGTH - 1] = '\0';
+            }
          }
 
          previous_sector_size = 0;


### PR DESCRIPTION
Prevent out of bounds write when copying to current_track_path. Fixes #222.