### PR TITLE
Restore `RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS` backwards-compatibility

### DIFF
--- a/include/libretro.h
+++ b/include/libretro.h
@@ -722,9 +722,10 @@ enum retro_mod
  */
 
 /**
- * This bit indicates that the associated environment call is experimental,
- * and may be changed or removed in the future.
- * Frontends should mask out this bit before handling the environment call.
+ * This bit used to indicate that the associated environment call is experimental,
+ * and may be changed or removed in the future, but this has since changed.
+ * Frontends should NOT mask out this bit before handling the environment call,
+ * as some callbacks need it to distinguish themselves from others.
  */
 #define RETRO_ENVIRONMENT_EXPERIMENTAL 0x10000
 
@@ -1682,6 +1683,22 @@ enum retro_mod
  * @see RETRO_ENVIRONMENT_SET_HW_RENDER
  */
 #define RETRO_ENVIRONMENT_SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE (43 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+
+/**
+ * Notifies the frontend of any quirks associated with serialization.
+ *
+ * Should be set in either \c retro_init or \c retro_load_game, but not both.
+ * @param[in, out] data <tt>uint64_t *</tt>.
+ * Pointer to the core's serialization quirks.
+ * The frontend will set the flags of the quirks it supports
+ * and clear the flags of those it doesn't.
+ * Behavior is undefined if \c NULL.
+ * @return \c true if this environment call is supported.
+ * @see retro_serialize
+ * @see retro_unserialize
+ * @see RETRO_SERIALIZATION_QUIRK
+ */
+#define RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS 44
 
 /**
  * The frontend will try to use a "shared" context when setting up a hardware context.
@@ -2718,20 +2735,12 @@ enum retro_mod
 #define RETRO_ENVIRONMENT_GET_MEMORY_STATUS (86 | RETRO_ENVIRONMENT_EXPERIMENTAL)
 
 /**
- * Notifies the frontend of any quirks associated with serialization.
+ * Legacy compatibility shim to RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS.
+ * Cores should avoid using this, as it is not as well-supported.
  *
- * Should be set in either \c retro_init or \c retro_load_game, but not both.
- * @param[in, out] data <tt>uint64_t *</tt>.
- * Pointer to the core's serialization quirks.
- * The frontend will set the flags of the quirks it supports
- * and clear the flags of those it doesn't.
- * Behavior is undefined if \c NULL.
- * @return \c true if this environment call is supported.
- * @see retro_serialize
- * @see retro_unserialize
- * @see RETRO_SERIALIZATION_QUIRK
+ * @see RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS
  */
-#define RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS 87
+#define RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS_2 87
 
 /**
  * Queries whether the active video driver can present a 10-bit-per-channel


### PR DESCRIPTION
In https://github.com/libretro/RetroArch/pull/19161 and https://github.com/libretro/RetroArch/pull/19169, the clash reported in libretro#89 was addressed by changing `RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS` from 44 to 87.

This is not ideal, as it breaks backwards-compatibility with existing frontends, including stable releases of RetroArch. Additionally, while the documentation does explicitly say that commands tagged with `RETRO_ENVIRONMENT_EXPERIMENTAL` may be subject to change in the future, `RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS` is not one of those commands, making this breakage a violation of the promises made by the API.

To resolve this, `RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS` has been moved back to 44, with a compatibility shim left to occupy 87, and `RETRO_ENVIRONMENT_EXPERIMENTAL` has effectively been deprecated, now just being a regular part of the command ID. This allows the two clashing commands to be distinguished by their experimental bit.

The documentation does say that `RETRO_ENVIRONMENT_EXPERIMENTAL` should be filtered-out by frontends, but [not even RetroArch actually does this](https://github.com/libretro/RetroArch/blob/254f34d46aecb8b270bd2b8f01c57f344019d2a7/runloop.c#L1471). For years, my own libretro frontend has resorted to this same hack to work around the clashing commands, and I imagine many other frontends already do so as well.

Since experimental commands never seem to change or be promoted to a non-experimental command ID, I think it is best to retire the bit entirely and just let it be part of the ID. For good measure, the constant could be removed, and the bit baked directly into the command ID values, that way frontend developers who do use `RETRO_ENVIRONMENT_EXPERIMENTAL` are implicitly notified to stop filtering it out, and nudged towards the 'correct' behaviour.

Closes #89.